### PR TITLE
Rename section manifest.app -> manifest.store in the JSON schema.

### DIFF
--- a/docs/schema/2.0/manifest.schema.json
+++ b/docs/schema/2.0/manifest.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://github.com/getoutreach/extensibility-sdk/docs/schema/2.0/manifest.schema.json",
   "properties": {
-    "app": {
+    "store": {
       "type": "object",
       "properties": {
         "author": {
@@ -23,7 +23,7 @@
             "supportUrl": {
               "type": "string",
               "format": "uri"
-            },            
+            },
             "company": {
               "type": "string"
             },

--- a/tests/validator.test.ts
+++ b/tests/validator.test.ts
@@ -288,6 +288,7 @@ const getNewValidApplicationManifest = (): Application => {
       email: 'author@someurl.com',
       company: 'Acme ltd',
       privacyUrl: 'https://someurl.com/privacy',
+      supportUrl: 'https://someurl.com/support',
       termsOfUseUrl: 'https://someurl.com/tos',
       websiteUrl: 'https://someurl.com/',
     },


### PR DESCRIPTION
For some reason, we had been using "manifest.app" instead of "manifest.store" in the JSON schema. Renamed.