### PR TITLE
OREX-741 Renaming notUseSdk to disableTimeoutMonitoring

### DIFF
--- a/docs/url-parsing.md
+++ b/docs/url-parsing.md
@@ -26,7 +26,7 @@ As mentioned in [hosting requirements](host-requirements.md#timeouts), the Outre
 
 ![alt text](assets/timeout-error.png "Timeout error screen")
 
-A lot of  the applications are implemented based on manual URL parsing. In that case, they doesn't reference the SDK, and thus the READY message event is not sent, which leads to an error screen even if the application is working fine.
+A lot of the applications are implemented based on manual URL parsing. In that case, they don't reference the SDK, and thus the READY message event is not sent, which leads to an error screen even if the application is working fine.
 
 There are two recommended solutions to tackle this if the application code can be modified:
 
@@ -38,12 +38,12 @@ const addonHostOrigin = ‘https://app-hosting-domain.com;
 window.parent.postMessage({type: ‘cxt:sdk:ready’, version: 2}, addonHostOrigin)
 ```
 
-Only in the extreme case when modifications to the application page are not possible and recomended solutions are not possible, application creator can update manifest with information that application is "not using the SDK," so the Outreach host will skip the timeout check. This is not recomended, as Outreach host will not have any information on application QoS and it would have to be approved as an exception during the application review process.
+When the recommended solutions are not possible, the application creator can update the manifest with information that the application is "not using the SDK" and that the Outreach host will disable the timeout check. With this solution, the Outreach host will not have any information on application QoS, and it would have to be approved as an exception during the application review process.
 
 ```javascript
 {
   ...
-  notUsingSdk: true
+  disableTimeoutMonitoring: true
   ...
 } 
 ```

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outreach/extensibility-sdk",
   "license": "MIT",
-  "version": "0.4.94",
+  "version": "0.4.95",
   "private": false,
   "contributors": [
     "Outreach Client Extensibility Team <cxt-sdk@outreach.io>"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outreach/extensibility-sdk",
   "license": "MIT",
-  "version": "0.4.95",
+  "version": "0.4.96",
   "private": false,
   "contributors": [
     "Outreach Client Extensibility Team <cxt-sdk@outreach.io>"

--- a/src/legacy/ManifestTranslator.ts
+++ b/src/legacy/ManifestTranslator.ts
@@ -117,7 +117,7 @@ export class ManifestTranslator {
       version: app.store.version,
       api: app.api,
       medias: app.store.medias,
-      notUsingSdk: app.notUsingSdk,
+      disableTimeoutMonitoring: app.notUsingSdk || app.disableTimeoutMonitoring,
     };
 
     return manifestV1;
@@ -143,7 +143,7 @@ export class ManifestTranslator {
     }
 
     const app: Application = new Application();
-    app.notUsingSdk = firstExt.notUsingSdk;
+    app.notUsingSdk = firstExt.notUsingSdk || firstExt.disableTimeoutMonitoring;
     app.store = new ManifestStore();
     app.store.author = new ManifestAuthor();
     app.store.author.company = firstExt.author.company || 'N/A';

--- a/src/legacy/ManifestTranslator.ts
+++ b/src/legacy/ManifestTranslator.ts
@@ -89,7 +89,6 @@ export class ManifestTranslator {
       return null;
     }
 
-    const appExt = ext.type === ShellExtensionType.APPLICATION;
     const tabExt =
       ext.type === TabExtensionType.ACCOUNT ||
       ext.type === TabExtensionType.PROSPECT ||
@@ -104,11 +103,17 @@ export class ManifestTranslator {
       host: {
         icon: ext.host.icon,
         url: ext.host.url,
-        notificationsUrl: appExt ? ext.host.notificationsUrl || '' : '',
+        notificationsUrl:
+          ext.host instanceof ShellExtensionHost
+            ? ext.host.notificationsUrl || ''
+            : '',
         type: manifestType,
         environment: {
           fullWidth: tabExt,
-          decoration: appExt ? ext.host.decoration : 'none',
+          decoration:
+            ext.host instanceof ShellExtensionHost
+              ? ext.host.decoration
+              : 'none',
         },
       },
       identifier: ext.identifier,
@@ -143,7 +148,8 @@ export class ManifestTranslator {
     }
 
     const app: Application = new Application();
-    app.notUsingSdk = firstExt.notUsingSdk || firstExt.disableTimeoutMonitoring;
+    app.disableTimeoutMonitoring =
+      firstExt.notUsingSdk || firstExt.disableTimeoutMonitoring;
     app.store = new ManifestStore();
     app.store.author = new ManifestAuthor();
     app.store.author.company = firstExt.author.company || 'N/A';
@@ -227,17 +233,23 @@ export class ManifestTranslator {
     extension.fullWidth = ext.host.environment?.fullWidth || false;
 
     extension.context = ext.context.map((ctx) => {
-      const accountKey = this.getEnumKeyByEnumValue(AccountContextKeys, ctx);
+      const accountKey = ManifestTranslator.getEnumKeyByEnumValue(
+        AccountContextKeys,
+        ctx
+      );
       if (accountKey) {
         return AccountContextKeys[accountKey];
       }
 
-      const prospectKey = this.getEnumKeyByEnumValue(ProspectContextKeys, ctx);
+      const prospectKey = ManifestTranslator.getEnumKeyByEnumValue(
+        ProspectContextKeys,
+        ctx
+      );
       if (prospectKey) {
         return ProspectContextKeys[prospectKey];
       }
 
-      const opportunityKey = this.getEnumKeyByEnumValue(
+      const opportunityKey = ManifestTranslator.getEnumKeyByEnumValue(
         OpportunityContextKeys,
         ctx
       );
@@ -245,12 +257,18 @@ export class ManifestTranslator {
         return OpportunityContextKeys[opportunityKey];
       }
 
-      const userKey = this.getEnumKeyByEnumValue(UserContextKeys, ctx);
+      const userKey = ManifestTranslator.getEnumKeyByEnumValue(
+        UserContextKeys,
+        ctx
+      );
       if (userKey) {
         return UserContextKeys[userKey];
       }
 
-      const clientKey = this.getEnumKeyByEnumValue(ClientContextKeys, ctx);
+      const clientKey = ManifestTranslator.getEnumKeyByEnumValue(
+        ClientContextKeys,
+        ctx
+      );
       if (clientKey) {
         return ClientContextKeys[clientKey];
       }
@@ -300,12 +318,18 @@ export class ManifestTranslator {
     }
 
     extension.context = ext.context.map((ctx) => {
-      const userKey = this.getEnumKeyByEnumValue(UserContextKeys, ctx);
+      const userKey = ManifestTranslator.getEnumKeyByEnumValue(
+        UserContextKeys,
+        ctx
+      );
       if (userKey) {
         return UserContextKeys[userKey];
       }
 
-      const clientKey = this.getEnumKeyByEnumValue(ClientContextKeys, ctx);
+      const clientKey = ManifestTranslator.getEnumKeyByEnumValue(
+        ClientContextKeys,
+        ctx
+      );
       if (clientKey) {
         return ClientContextKeys[clientKey];
       }

--- a/src/legacy/ManifestV1.ts
+++ b/src/legacy/ManifestV1.ts
@@ -42,5 +42,13 @@ export interface ManifestV1 {
 
   medias?: ManifestMedia[];
 
+  /**
+   *
+   * @deprecated Use disableTimeoutMonitoring
+   * @type {boolean}
+   * @memberof ManifestV1
+   */
   notUsingSdk?: boolean;
+
+  disableTimeoutMonitoring?: boolean;
 }

--- a/src/manifest/Application.ts
+++ b/src/manifest/Application.ts
@@ -69,6 +69,21 @@ export class Application {
    *
    * @type {boolean}
    * @memberof Application
+   * @deprecated use disableTimeoutMonitoring instead
    */
+
   public notUsingSdk?: boolean;
+
+  /**
+   * An optional property defining if the application is created without using the extensibility SDK.
+   * This apps are manually parsing of the iframe URL containing the context value parameters and not
+   * sending the READY message back to the Outreach host so the timeout can not be monitored due to that.
+   *
+   * If omitted in manifest, the default value is false.
+   *
+   * @see https://github.com/getoutreach/extensibility-sdk/blob/main/docs/url-parsing.md#timeout-handling
+   * @type {boolean}
+   * @memberof Application
+   */
+  public disableTimeoutMonitoring?: boolean;
 }

--- a/src/manifest/extensions/Extension.ts
+++ b/src/manifest/extensions/Extension.ts
@@ -31,8 +31,8 @@ export abstract class Extension {
    * Definition of addon host
    *
    * @see https://github.com/getoutreach/extensibility-sdk/blob/master/docs/manifest.md#host
-   * @type {TabManifestHost}
-   * @memberof TabExtension
+   * @type {ExtensionHost}
+   * @memberof Extension
    */
   public host: ExtensionHost;
 

--- a/tests/translator.test.ts
+++ b/tests/translator.test.ts
@@ -106,6 +106,24 @@ describe('Manifest translator tests', () => {
     expect(tabOpportunityExt.title).toBe(v1Manifests[2].title);
     expect(tabOpportunityExt.version).toBe(v1Manifests[2].version);
   });
+
+  describe('disableTimeoutMonitoring', () => {
+    test('if omitted in manifest, it is false', () => {
+      const result = ManifestTranslator.getAppManifest(v1Manifests);
+      expect(result!.disableTimeoutMonitoring).toBeFalsy();
+    });
+
+    test('preserved through translation', () => {
+      v1Manifests[0].disableTimeoutMonitoring = true;
+      const result = ManifestTranslator.getAppManifest(v1Manifests);
+      expect(result!.disableTimeoutMonitoring).toBe(true);
+    });
+    test('it replaces notUsingSdk', () => {
+      v1Manifests[0].notUsingSdk = true;
+      const result = ManifestTranslator.getAppManifest(v1Manifests);
+      expect(result!.disableTimeoutMonitoring).toBe(true);
+    });
+  });
 });
 
 const v1Manifests = [

--- a/tests/validator.test.ts
+++ b/tests/validator.test.ts
@@ -288,6 +288,7 @@ const getNewValidApplicationManifest = (): Application => {
       email: 'author@someurl.com',
       company: 'Acme ltd',
       privacyUrl: 'https://someurl.com/privacy',
+      supportUrl: 'https://someurl.com/support',
       termsOfUseUrl: 'https://someurl.com/tos',
       websiteUrl: 'https://someurl.com/',
     },


### PR DESCRIPTION
[OREX-741]

In order to avoid having non-intuitive, negative manifest property names we are renaming **notUseSdk** to **dsiableTimeoutMonitoring**

[OREX-741]: https://outreach-io.atlassian.net/browse/OREX-741?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ