### PR TITLE
Move identifier to the root of application manifest

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -7,12 +7,12 @@ Table of content:
 - [Manifest file](#manifest-file)
   - [Sample manifest](#sample-manifest)
   - [Manifest JSON schema](#manifest-json-schema)
+    - [identifier](#identifier)
   - [Store section properties (store)](#store-section-properties-store)
     - [author](#author)
     - [categories](#categories)
     - [description](#description)
     - [headline](#headline)
-    - [identifier](#identifier)
     - [icon (of application)](#icon-of-application)
     - [locales](#locales)
     - [medias](#medias)
@@ -59,6 +59,7 @@ Here is the sample manifest file of the hello world application having two exten
 
 ```json
 {
+  "identifier": "app-identifier",
   "store": {
     "author": {
       "company": "Acme ltd",
@@ -78,7 +79,6 @@ Here is the sample manifest file of the hello world application having two exten
       "en": "Some short description (en)"
     },
     "iconUrl": "https://someurl.com/image.png",
-    "identifier": "app-identifier",
     "locales": [
       "en"
     ],
@@ -164,6 +164,9 @@ Internally we validate each submitted manifest using the following schema
 [Manifest JSON schema v2.0](schema/2.0/manifest.schema.json)
 
 A manifest can be validated using the [online tool](https://www.jsonschemavalidator.net/)
+### identifier
+
+Unique identifier of the application as defined by the application creator. The identifier may contain uppercase or lowercase letters ('A' through 'Z'), numbers, underscores ('_'), hyphens('-') and dots('.'). The minimum length is 6 characters a the maximum is 128.
 
 ## Store section properties (store)
 
@@ -191,10 +194,6 @@ A localized application description is shown in the Outreach Marketplace at appl
 ### headline
 
 A localized application headline is shown in the Outreach Marketplace together with title and icon at the application list/tiles page as well as at application details page.
-
-### identifier
-
-Unique identifier of the application as defined by the application creator. The identifier may contain uppercase or lowercase letters ('A' through 'Z'), numbers, underscores ('_'), hyphens('-') and dots('.'). The minimum length is 6 characters a the maximum is 128.
 
 ### icon (of application)
 

--- a/docs/schema/2.0/manifest.schema.json
+++ b/docs/schema/2.0/manifest.schema.json
@@ -2,6 +2,12 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://github.com/getoutreach/extensibility-sdk/docs/schema/2.0/manifest.schema.json",
   "properties": {
+    "identifier": {
+      "type": "string",
+      "minLength": 6,
+      "maxLength": 128,
+      "pattern": "^[a-zA-Z0-9._-]+$"
+    },
     "store": {
       "type": "object",
       "properties": {
@@ -84,12 +90,6 @@
           "type": "string",
           "format": "uri"
         },
-        "identifier": {
-          "type": "string",
-          "minLength": 6,
-          "maxLength": 128,
-          "pattern": "^[a-zA-Z0-9._-]+$"
-        },
         "locales": {
           "type": "array",
           "items": {
@@ -135,7 +135,6 @@
         "headline",
         "description",
         "icon",
-        "identifier",
         "title",
         "version"
       ]
@@ -289,5 +288,5 @@
       }
     }
   },
-  "required": ["store", "extensions"]
+  "required": ["identifier", "store", "extensions"]
 }

--- a/src/legacy/ManifestTranslator.ts
+++ b/src/legacy/ManifestTranslator.ts
@@ -160,6 +160,7 @@ export class ManifestTranslator {
     const app: Application = new Application();
     app.disableTimeoutMonitoring =
       firstExt.notUsingSdk || firstExt.disableTimeoutMonitoring;
+    app.identifier = firstExt.identifier;
     app.store = new ManifestStore();
     app.store.author = new ManifestAuthor();
     app.store.author.company = firstExt.author.company || 'N/A';
@@ -172,7 +173,6 @@ export class ManifestTranslator {
 
     app.store.description = firstExt.description;
     app.store.iconUrl = '';
-    app.store.identifier = firstExt.identifier;
     app.store.locales = [Locale.ENGLISH];
     app.store.medias = [];
     app.store.headline = firstExt.title;
@@ -295,6 +295,8 @@ export class ManifestTranslator {
 
   public static hydrate = (app: Application): Application => {
     const application = new Application();
+    application.identifier = app.identifier;
+
     if (app.api) {
       application.api = Object.assign(new ManifestApi(), app.api);
     }

--- a/src/manifest/Application.ts
+++ b/src/manifest/Application.ts
@@ -53,6 +53,15 @@ export class Application {
   public extensions: Extension[] = [];
 
   /**
+   * Unique application identifier
+   *
+   * @see https://github.com/getoutreach/extensibility-sdk/blob/master/docs/manifest.md#identifier
+   * @type {string}
+   * @memberof ManifestStore
+   */
+  public identifier: string = '';
+
+  /**
    * App section contains the data describing Outreach application containing
    * one or more extensions.
    *

--- a/src/manifest/ManifestStore.ts
+++ b/src/manifest/ManifestStore.ts
@@ -7,15 +7,6 @@ import { Locale } from '../sdk/Locale';
 
 export class ManifestStore {
   /**
-   * Unique application identifier
-   *
-   * @see https://github.com/getoutreach/extensibility-sdk/blob/master/docs/manifest.md#identifier
-   * @type {string}
-   * @memberof ManifestStore
-   */
-  public identifier: string = '';
-
-  /**
    * List of culture locales supported by the extension
    *
    * @type {Locale[]}

--- a/src/sdk/Validator.ts
+++ b/src/sdk/Validator.ts
@@ -11,6 +11,10 @@ import { StoreType } from '../manifest/store/StoreType';
  */
 export const validate = (application: Application): string[] => {
   const issues: string[] = [];
+  if (!application.identifier) {
+    issues.push('Manifest identifier definition is missing.');
+  }
+
   if (application.api) {
     if (!application.api.scopes) {
       issues.push('Undefined api scopes');
@@ -152,10 +156,6 @@ export const validate = (application: Application): string[] => {
         'Application icon url is invalid url. Value: ' + application.store.iconUrl
       );
     }
-  }
-
-  if (!application.store.identifier) {
-    issues.push('Manifest identifier definition is missing.');
   }
 
   if (!application.store.title) {

--- a/tests/translator.test.ts
+++ b/tests/translator.test.ts
@@ -21,6 +21,8 @@ describe('Manifest translator tests', () => {
 
     expect(result).not.toBeNull();
 
+    expect(result!.identifier).toBe(v1Manifests[0].identifier);
+
     expect(result!.extensions.length).toBe(3);
 
     expect(result!.store.author.company).toBe('N/A');
@@ -36,7 +38,6 @@ describe('Manifest translator tests', () => {
     expect(result!.store.headline).toBe(v1Manifests[0].title);
     expect(result!.store.iconUrl).toBe('');
 
-    expect(result!.store.identifier).toBe(v1Manifests[0].identifier);
     expect(result!.store.locales).toEqual([Locale.ENGLISH]);
     expect(result!.store.medias).toEqual([]);
     expect(result!.store.title).toEqual(v1Manifests[0].title);

--- a/tests/validator.test.ts
+++ b/tests/validator.test.ts
@@ -283,6 +283,7 @@ const getNewValidApplicationManifest = (): Application => {
   appTabExtension.context = [UserContextKeys.ID];
 
   const application = new Application();
+  application.identifier = 'app-identifier',
   application.store = {
     author: {
       email: 'author@someurl.com',
@@ -319,7 +320,6 @@ const getNewValidApplicationManifest = (): Application => {
       'es-LA': 'Spanish',
       'fr-FR': 'French',
     },
-    identifier: 'app-identifier',
     iconUrl: 'https://someurl.com/icon',
     locales: [Locale.ENGLISH],
     type: StoreType.PRIVATE,


### PR DESCRIPTION
OrexService, Giraffe and DevPortal operate with a model of manifest containing application identifier at the root of application manifest.

Updating our SDK and docs to match the reality :)