### PR TITLE
[oree-842] Adding support for webhook to manifest

### DIFF
--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -19,13 +19,14 @@ Table of content:
     - [title](#title)
     - [version](#version)
   - [Outreach Oauth API access section ("api")](#outreach-oauth-api-access-section-api)
-    - [applicationId](#applicationid)
-    - [redirectUri](#redirecturi)
     - [scopes](#scopes)
-    - [connect](#connect)
     - [client](#client)
     - [redirectUris](#redirecturis)
+  - [Webhooks](#webhooks)
+    - [events](#events)
+    - [url](#url)
   - [Configuration section (configuration)](#configuration-section-configuration)
+  - [External installation Url](#external-installation-url)
   - [Extensions section (extensions)](#extensions-section-extensions)
     - [Shared extension properties](#shared-extension-properties)
       - [identifier (extension)](#identifier-extension)
@@ -41,7 +42,7 @@ Table of content:
         - [fullWidth (tab extension)](#fullwidth-tab-extension)
         - [decoration (shell extension)](#decoration-shell-extension)
       - [Host (tab extension)](#host-tab-extension)
-        - [url](#url)
+        - [url](#url-1)
       - [icon (of extension)](#icon-of-extension)
       - [type](#type)
       - [notificationsUrl](#notificationsurl)
@@ -105,6 +106,10 @@ opportunity tab extension.
       "id": "AbCd123456qW"
     },
     "redirectUris": ["https://application-host.com/hello-world"]
+  },
+  "webhooks": {
+    "events": ["*"],
+    "url": "https://application-host.com/webhook"
   },
   "externalInstallationUrl": "https://somestore.com/acme/application",
   "configuration": [
@@ -219,14 +224,6 @@ A version of the application manifest in the format MAJOR.MINOR
 
 This section is optional. If the application doesn't need access to outreach API, this section can be omitted.
 
-### applicationId
-
-This field is deprecated in favor of `client.id`.
-
-### redirectUri
-
-This field is deprecated in favor of `redirectUris`.
-
 ### scopes
 
 In the scopes section, the application creator defines Outreach API scopes needed for performing API calls the
@@ -239,11 +236,6 @@ requested scopes to the application
 
 ![API consent screen](assets/api-consent.png)
 
-### connect
-
-This value contains URL of the [connect endpoint](outreach-api.md#connect-endpoint). Note: The domain of the connect Uri
-has to be the same as the domain of the [host.url](#url)
-
 ### client
 
 The id of a client object is the value used for
@@ -255,6 +247,33 @@ This URLs are defined in Outreach OAuth settings, which the authorization form w
 consent with granting access to Outreach API in his name. These URLs can be the same as the [host url](#url) or a
 separate URL, but in both cases, it has to be implemented in a way matching
 [Outreach API access requirements](outreach-api.md).
+
+## Webhooks
+
+This section is optional. If the application doesn't need to be notified
+when certain application events happen on Outreach side, this section can be omitted.
+
+### events
+
+In the events section, application creator defines one or more events which
+Outreach should inform about when they occur.
+
+The list of supported events:
+
+- **"*"**  - all the events will be sent to addon creator
+- **"install"** - event will be sent when Outreach user installs application.
+- **"uninstall"** - event will be sent when Outreach user uninstalls application.
+- **"setup"** - event will be sent when Outreach user clicks in Marketplace on setup link
+
+Here are a few examples of the values:
+
+- ["*"] - All of the events will be sent
+- ["install", "uninstall"] -  Only the events related to installing and uninstalling of an app will be sent.
+
+### url
+
+This is the endpoint which addon creator wants to be called with the Outreach event information.
+It has to be valid endpoint which is accepting POST request.
 
 ## Configuration section (configuration)
 

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -24,7 +24,7 @@ Table of content:
     - [redirectUris](#redirecturis)
   - [Webhooks](#webhooks)
     - [events](#events)
-    - [url](#url)
+    - [url (events)](#url-events)
   - [Configuration section (configuration)](#configuration-section-configuration)
   - [External installation Url](#external-installation-url)
   - [Extensions section (extensions)](#extensions-section-extensions)
@@ -42,7 +42,7 @@ Table of content:
         - [fullWidth (tab extension)](#fullwidth-tab-extension)
         - [decoration (shell extension)](#decoration-shell-extension)
       - [Host (tab extension)](#host-tab-extension)
-        - [url](#url-1)
+        - [url (host)](#url-host)
       - [icon (of extension)](#icon-of-extension)
       - [type](#type)
       - [notificationsUrl](#notificationsurl)
@@ -250,17 +250,17 @@ separate URL, but in both cases, it has to be implemented in a way matching
 
 ## Webhooks
 
-This section is optional. If the application doesn't need to be notified
-when certain application events happen on Outreach side, this section can be omitted.
+This section is optional. If the application doesn't need to be notified when certain application events happen on
+Outreach side, this section can be omitted.
 
 ### events
 
-In the events section, application creator defines one or more events which
-Outreach should inform about when they occur.
+In the events section, application creator defines one or more events which Outreach should inform about when they
+occur.
 
 The list of supported events:
 
-- **"*"**  - all the events will be sent to addon creator
+- **"\*"** - all the events will be sent to addon creator
 - **"install"** - event will be sent when Outreach user installs application.
 - **"uninstall"** - event will be sent when Outreach user uninstalls application.
 - **"setup"** - event will be sent when Outreach user clicks in Marketplace on setup link
@@ -268,12 +268,12 @@ The list of supported events:
 Here are a few examples of the values:
 
 - ["*"] - All of the events will be sent
-- ["install", "uninstall"] -  Only the events related to installing and uninstalling of an app will be sent.
+- ["install", "uninstall"] - Only the events related to installing and uninstalling of an app will be sent.
 
-### url
+### url (events)
 
-This is the endpoint which addon creator wants to be called with the Outreach event information.
-It has to be valid endpoint which is accepting POST request.
+This is the endpoint which addon creator wants to be called with the Outreach event information. It has to be valid
+endpoint which is accepting POST request.
 
 ## Configuration section (configuration)
 
@@ -423,7 +423,7 @@ manifest.host.environment = {
 
 The host section contains the application hosting endpoints and attributes implemented by the application creator.
 
-##### url
+##### url (host)
 
 Address where the application hosting web page is hosted.
 

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -22,7 +22,7 @@ Table of content:
     - [scopes](#scopes)
     - [client](#client)
     - [redirectUris](#redirecturis)
-  - [Webhooks](#webhooks)
+  - [Webhook](#webhook)
     - [events](#events)
     - [url (events)](#url-events)
   - [Configuration section (configuration)](#configuration-section-configuration)
@@ -107,7 +107,7 @@ opportunity tab extension.
     },
     "redirectUris": ["https://application-host.com/hello-world"]
   },
-  "webhooks": {
+  "webhook": {
     "events": ["*"],
     "url": "https://application-host.com/webhook"
   },
@@ -248,7 +248,7 @@ consent with granting access to Outreach API in his name. These URLs can be the 
 separate URL, but in both cases, it has to be implemented in a way matching
 [Outreach API access requirements](outreach-api.md).
 
-## Webhooks
+## Webhook
 
 This section is optional. If the application doesn't need to be notified when certain application events happen on
 Outreach side, this section can be omitted.

--- a/docs/schema/2.0/manifest.schema.json
+++ b/docs/schema/2.0/manifest.schema.json
@@ -126,6 +126,22 @@
       },
       "required": ["author", "headline", "description", "icon", "identifier", "title", "version"]
     },
+    "webhooks": {
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri"
+        },
+        "events": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["*", "install", "uninstall", "setup"]
+          }
+        }
+      }
+    },
     "api": {
       "type": "object",
       "properties": {

--- a/docs/schema/2.0/manifest.schema.json
+++ b/docs/schema/2.0/manifest.schema.json
@@ -126,7 +126,7 @@
       },
       "required": ["author", "headline", "description", "icon", "identifier", "title", "version"]
     },
-    "webhooks": {
+    "webhook": {
       "type": "object",
       "properties": {
         "url": {

--- a/src/legacy/ManifestTranslator.ts
+++ b/src/legacy/ManifestTranslator.ts
@@ -146,7 +146,7 @@ export class ManifestTranslator {
       version: app.store.version,
       api: mapApi(),
       medias: app.store.medias,
-      disableTimeoutMonitoring: app.notUsingSdk || app.disableTimeoutMonitoring,
+      disableTimeoutMonitoring: app.disableTimeoutMonitoring,
     };
 
     return manifestV1;

--- a/src/manifest/Application.ts
+++ b/src/manifest/Application.ts
@@ -3,6 +3,7 @@ import { ConfigurationItem } from '../configuration/ConfigurationItem';
 import { Extension } from './extensions/Extension';
 import { ManifestApi } from './ManifestApi';
 import { ManifestStore } from './ManifestStore';
+import { ManifestWebhook } from './ManifestWebhook';
 
 /**
  * Definition of the application manifest file containing all of the information
@@ -62,19 +63,6 @@ export class Application {
   public store: ManifestStore;
 
   /**
-   * An optional property defining if the application is created without using the extensibility SDK
-   * by manually parsing of the iframe URL containing the context value parameters.
-   *
-   * If omitted in manifest, the default value is false.
-   *
-   * @type {boolean}
-   * @memberof Application
-   * @deprecated use disableTimeoutMonitoring instead
-   */
-
-  public notUsingSdk?: boolean;
-
-  /**
    * An optional property defining if the application is created without using the extensibility SDK.
    * This apps are manually parsing of the iframe URL containing the context value parameters and not
    * sending the READY message back to the Outreach host so the timeout can not be monitored due to that.
@@ -86,4 +74,16 @@ export class Application {
    * @memberof Application
    */
   public disableTimeoutMonitoring?: boolean;
+
+  /**
+   * An optional section containing the webhook definition enabling Outreach
+   * to send appropriate event information over webhook
+   *
+   * @see https://github.com/getoutreach/extensibility-sdk/blob/master/docs/manifest.md#webhooks
+   * @see https://github.com/getoutreach/extensibility-sdk/blob/master/docs/webhooks.md
+   *
+   * @type {ManifestWebhook}
+   * @memberof Application
+   */
+  public webhooks?: ManifestWebhook;
 }

--- a/src/manifest/Application.ts
+++ b/src/manifest/Application.ts
@@ -79,11 +79,11 @@ export class Application {
    * An optional section containing the webhook definition enabling Outreach
    * to send appropriate event information over webhook
    *
-   * @see https://github.com/getoutreach/extensibility-sdk/blob/master/docs/manifest.md#webhooks
-   * @see https://github.com/getoutreach/extensibility-sdk/blob/master/docs/webhooks.md
+   * @see https://github.com/getoutreach/extensibility-sdk/blob/master/docs/manifest.md#webhook
+   * @see https://github.com/getoutreach/extensibility-sdk/blob/master/docs/webhook.md
    *
    * @type {ManifestWebhook}
    * @memberof Application
    */
-  public webhooks?: ManifestWebhook;
+  public webhook?: ManifestWebhook;
 }

--- a/src/manifest/ManifestWebhook.ts
+++ b/src/manifest/ManifestWebhook.ts
@@ -1,0 +1,29 @@
+import { WebHookEvents } from './api/WebHookEvents';
+
+/**
+ * Optional section defining parameters needed for webhook eventing support.
+ * @see https://github.com/getoutreach/extensibility-sdk/blob/master/docs/manifest.md#webhooks-optional
+ * @see https://github.com/getoutreach/extensibility-sdk/blob/master/docs/webhooks.md
+ * @export
+ * @class ManifestWebhook
+ */
+export class ManifestWebhook {
+  /**
+   * The list of events will be used for Outreach to determine which are the platform events
+   * application creator should be informed about (e.g. application was installed)
+   *
+   * @see https://github.com/getoutreach/extensibility-sdk/blob/master/docs/manifest.md#events
+   *
+   * @type {WebHookEvents[]}
+   * @memberof ManifestWebhook
+   */
+  public events: WebHookEvents[];
+
+  /**
+   * A webhook endpoint url to which event information are being sent in a form of POST message.
+   *
+   * @type {string}
+   * @memberof ManifestWebhook
+   */
+  public url: string;
+}

--- a/src/manifest/api/WebHookEvents.ts
+++ b/src/manifest/api/WebHookEvents.ts
@@ -1,0 +1,11 @@
+/* eslint-disable no-unused-vars */
+
+export enum WebHookEvents {
+  ALL = '*',
+
+  INSTALL = 'install',
+
+  UNINSTALL = 'uninstall',
+
+  EXTERNAL_SETUP = 'setup',
+}

--- a/src/sdk/Validator.ts
+++ b/src/sdk/Validator.ts
@@ -44,24 +44,24 @@ export const validate = (application: Application): string[] => {
     }
   }
 
-  if (application.webhooks) {
-    if (!application.webhooks.events) {
+  if (application.webhook) {
+    if (!application.webhook.events) {
       issues.push('Undefined web hook events');
-    } else if (!Array.isArray(application.webhooks.events)) {
-      issues.push('Events value is not an array. Value: ' + application.webhooks.events);
+    } else if (!Array.isArray(application.webhook.events)) {
+      issues.push('Events value is not an array. Value: ' + application.webhook.events);
     } else {
-      application.webhooks.events.forEach((event) => {
+      application.webhook.events.forEach((event) => {
         if (!Object.values(WebHookEvents).includes(event as WebHookEvents)) {
           issues.push('Invalid web hook event value. Value: ' + event);
         }
       });
     }
 
-    if (!application.webhooks.url) {
+    if (!application.webhook.url) {
       issues.push('Undefined web hook url.');
     } else {
-      if (!utils.urlValidation(application.webhooks.url)) {
-        issues.push('Manifest Webhook section needs to have valid url. Value: ' + application.webhooks.url);
+      if (!utils.urlValidation(application.webhook.url)) {
+        issues.push('Manifest Webhook section needs to have valid url. Value: ' + application.webhook.url);
       }
     }
   }

--- a/src/sdk/Validator.ts
+++ b/src/sdk/Validator.ts
@@ -2,6 +2,7 @@ import { utils } from '../utils';
 import { Application } from '../manifest/Application';
 import { Scopes } from '../manifest/api/Scopes';
 import { StoreType } from '../manifest/store/StoreType';
+import { WebHookEvents } from '../manifest/api/WebHookEvents';
 
 /**
  * Validates given manifest if it contains all of the required fields with correct values.
@@ -40,6 +41,28 @@ export const validate = (application: Application): string[] => {
           issues.push('Manifest Api section needs to have valid redirect urls. Value: ' + redirectUri);
         }
       });
+    }
+  }
+
+  if (application.webhooks) {
+    if (!application.webhooks.events) {
+      issues.push('Undefined web hook events');
+    } else if (!Array.isArray(application.webhooks.events)) {
+      issues.push('Events value is not an array. Value: ' + application.webhooks.events);
+    } else {
+      application.webhooks.events.forEach((event) => {
+        if (!Object.values(WebHookEvents).includes(event as WebHookEvents)) {
+          issues.push('Invalid web hook event value. Value: ' + event);
+        }
+      });
+    }
+
+    if (!application.webhooks.url) {
+      issues.push('Undefined web hook url.');
+    } else {
+      if (!utils.urlValidation(application.webhooks.url)) {
+        issues.push('Manifest Webhook section needs to have valid url. Value: ' + application.webhooks.url);
+      }
     }
   }
 

--- a/tests/validator.test.ts
+++ b/tests/validator.test.ts
@@ -97,10 +97,10 @@ describe('manifest tests', () => {
     });
   });
 
-  describe('webhooks', () => {
+  describe('webhook', () => {
     test('it can be undefined', () => {
       const manifest: Application = getNewValidApplicationManifest();
-      delete manifest.webhooks;
+      delete manifest.webhook;
       var issues = validate(manifest);
       expect(issues.length).toBe(0);
     });
@@ -108,7 +108,7 @@ describe('manifest tests', () => {
     test('events are mandatory', () => {
       const manifest: Application = getNewValidApplicationManifest();
 
-      manifest.webhooks!.events = undefined as any;
+      manifest.webhook!.events = undefined as any;
 
       var issues = validate(manifest);
       expect(issues.length).toBe(1);
@@ -118,7 +118,7 @@ describe('manifest tests', () => {
     test('only valid events should be acceptable', () => {
       const manifest: Application = getNewValidApplicationManifest();
 
-      manifest.webhooks!.events = ['BANANAS', WebHookEvents.ALL] as any;
+      manifest.webhook!.events = ['BANANAS', WebHookEvents.ALL] as any;
 
       var issues = validate(manifest);
       expect(issues.length).toBe(1);
@@ -128,7 +128,7 @@ describe('manifest tests', () => {
     test('redirect uri is mandatory', () => {
       const manifest: Application = getNewValidApplicationManifest();
 
-      manifest.webhooks!.url = undefined as any;
+      manifest.webhook!.url = undefined as any;
 
       var issues = validate(manifest);
       expect(issues.length).toBe(1);
@@ -137,7 +137,7 @@ describe('manifest tests', () => {
 
     test('webhook uri should be valid url', () => {
       const manifest = getNewValidApplicationManifest();
-      manifest.webhooks!.url = 'BANANAS';
+      manifest.webhook!.url = 'BANANAS';
 
       var issues = validate(manifest);
       expect(issues.length).toBe(1);
@@ -352,7 +352,7 @@ const getNewValidApplicationManifest = (): Application => {
     },
   };
 
-  application.webhooks = {
+  application.webhook = {
     events: [WebHookEvents.ALL],
     url: 'https://addon-host.com/webhook',
   };

--- a/tests/validator.test.ts
+++ b/tests/validator.test.ts
@@ -13,6 +13,7 @@ import { OpportunityContextKeys } from '../src/context/keys/OpportunityContextKe
 import { UserContextKeys } from '../src/context/keys/UserContextKeys';
 import { ApplicationShellExtension } from '../src/manifest/extensions/shell/types/ApplicationShellExtension';
 import { DecorationStyle } from '../src';
+import { WebHookEvents } from '../src/manifest/api/WebHookEvents';
 
 describe('manifest tests', () => {
   describe('valid', () => {
@@ -93,6 +94,54 @@ describe('manifest tests', () => {
       var issues = validate(manifest);
       expect(issues.length).toBe(1);
       expect(issues[0]).toBe('Manifest Api section needs to have valid redirect urls. Value: bananas');
+    });
+  });
+
+  describe('webhooks', () => {
+    test('it can be undefined', () => {
+      const manifest: Application = getNewValidApplicationManifest();
+      delete manifest.webhooks;
+      var issues = validate(manifest);
+      expect(issues.length).toBe(0);
+    });
+
+    test('events are mandatory', () => {
+      const manifest: Application = getNewValidApplicationManifest();
+
+      manifest.webhooks!.events = undefined as any;
+
+      var issues = validate(manifest);
+      expect(issues.length).toBe(1);
+      expect(issues[0]).toBe('Undefined web hook events');
+    });
+
+    test('only valid events should be acceptable', () => {
+      const manifest: Application = getNewValidApplicationManifest();
+
+      manifest.webhooks!.events = ['BANANAS', WebHookEvents.ALL] as any;
+
+      var issues = validate(manifest);
+      expect(issues.length).toBe(1);
+      expect(issues[0]).toBe('Invalid web hook event value. Value: BANANAS');
+    });
+
+    test('redirect uri is mandatory', () => {
+      const manifest: Application = getNewValidApplicationManifest();
+
+      manifest.webhooks!.url = undefined as any;
+
+      var issues = validate(manifest);
+      expect(issues.length).toBe(1);
+      expect(issues[0]).toBe('Undefined web hook url.');
+    });
+
+    test('webhook uri should be valid url', () => {
+      const manifest = getNewValidApplicationManifest();
+      manifest.webhooks!.url = 'BANANAS';
+
+      var issues = validate(manifest);
+      expect(issues.length).toBe(1);
+      expect(issues[0]).toBe('Manifest Webhook section needs to have valid url. Value: BANANAS');
     });
   });
 
@@ -301,6 +350,11 @@ const getNewValidApplicationManifest = (): Application => {
     client: {
       id: 'AbCd123456qW',
     },
+  };
+
+  application.webhooks = {
+    events: [WebHookEvents.ALL],
+    url: 'https://addon-host.com/webhook',
   };
 
   application.extensions = [appTabExtension, opportunityTabExtension];


### PR DESCRIPTION
This PR is defining webhooks-related application attributes in manifest,  SDK, and in OREX service schema 


`app {
  webhooks: {
      events: ["*"],
      url: "https://application-host.com/webhook"
  }
}`
