### PR TITLE
Creating dedicated extension type enum for editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outreach/extensibility-sdk",
   "license": "MIT",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "private": false,
   "contributors": [
     "Outreach Client Extensibility Team <cxt-sdk@outreach.io>"

--- a/src/index.ts
+++ b/src/index.ts
@@ -131,6 +131,8 @@ export { CompanionShellExtension } from './manifest/extensions/shell/types/Compa
 export { SidekickShellExtension } from './manifest/extensions/shell/types/SidekickShellExtension';
 export { ToolShellExtension } from './manifest/extensions/shell/types/ToolShellExtension';
 
+export { ContentExtensionType } from './manifest/extensions/editor/ContentExtensionType';
+
 export { TabExtension } from './manifest/extensions/tabs/TabExtension';
 export { TabExtensionType } from './manifest/extensions/tabs/TabExtensionType';
 export { AccountTabExtension } from './manifest/extensions/tabs/types/AccountTabExtension';

--- a/src/manifest/extensions/ExtensionGuards.ts
+++ b/src/manifest/extensions/ExtensionGuards.ts
@@ -1,3 +1,4 @@
+import { ContentExtensionType } from './editor/ContentExtensionType';
 import { EditorExtension } from './editor/EditorExtension';
 import { ShellExtensionType } from './shell/ShellExtensionType';
 import { ApplicationShellExtension } from './shell/types/ApplicationShellExtension';
@@ -234,7 +235,7 @@ export const isEditorShellExtension = (extension: any): extension is EditorExten
     return false;
   }
 
-  if (extension.type !== ShellExtensionType.EDITOR) {
+  if (extension.type !== ContentExtensionType.EDITOR) {
     return false;
   }
 

--- a/src/manifest/extensions/ExtensionType.ts
+++ b/src/manifest/extensions/ExtensionType.ts
@@ -1,3 +1,4 @@
+import { ContentExtensionType } from './editor/ContentExtensionType';
 import { ShellExtensionType } from './shell/ShellExtensionType';
 import { ActionShellExtension } from './shell/types/ActionShellExtension';
 import { ApplicationShellExtension } from './shell/types/ApplicationShellExtension';
@@ -15,7 +16,7 @@ import { AccountTileExtension } from './tiles/types/AccountTileExtension';
 import { OpportunityTileExtension } from './tiles/types/OpportunityTileExtension';
 import { ProspectTileExtension } from './tiles/types/ProspectTileExtension';
 
-export type ExtensionType = TabExtensionType | TileExtensionType | ShellExtensionType;
+export type ExtensionType = TabExtensionType | TileExtensionType | ShellExtensionType | ContentExtensionType;
 
 export type ProspectExtensionType =
   | TabExtensionType.PROSPECT

--- a/src/manifest/extensions/editor/ContentExtensionType.ts
+++ b/src/manifest/extensions/editor/ContentExtensionType.ts
@@ -1,0 +1,15 @@
+/* eslint-disable no-unused-vars */
+/**
+ * List of supported addon types.
+ * @see https://github.com/getoutreach/extensibility-sdk/blob/master/docs/manifest.md#type
+ * @export
+ * @enum {number}
+ */
+export enum ContentExtensionType {
+  /**
+   * Editor extension is show as a toolbar of icons extending the editor
+   * with a set of 3rd party tools which are loaded in a iframe popup
+   * once editor user clicks on some of the icons.
+   */
+  EDITOR = 'content-editor',
+}

--- a/src/manifest/extensions/editor/EditorExtension.ts
+++ b/src/manifest/extensions/editor/EditorExtension.ts
@@ -9,9 +9,8 @@ import logger from '../../../sdk/logging/Logger';
 import { UserContextKeys } from '../../../context/keys/UserContextKeys';
 import { ClientContextKeys } from '../../../context/keys/ClientContextKeys';
 import { OrganizationContextKeys } from '../../../context/keys/OrganizationContextKeys';
-import { ShellExtensionType } from '../shell/ShellExtensionType';
 import { EditorSettings } from './EditorSettings';
-import { ExtensionHost } from '../ExtensionHost';
+import { ContentExtensionType } from './ContentExtensionType';
 
 export class EditorExtension extends Extension {
   /**
@@ -27,21 +26,12 @@ export class EditorExtension extends Extension {
   public context: (UserContextKeys | ClientContextKeys | OrganizationContextKeys)[];
 
   /**
-   * Definition of addon host
-   *
-   * @see https://github.com/getoutreach/extensibility-sdk/blob/master/docs/manifest.md#host
-   * @type {ExtensionHost}
-   * @memberof EditorExtension
-   */
-  public host: ExtensionHost;
-
-  /**
    * Type property defines the type of tab extension
    * @see https://github.com/getoutreach/extensibility-sdk/blob/master/docs/manifest.md#type
-   * @type {ShellExtensionType.EDITOR}
+   * @type {ContentExtensionType.EDITOR}
    * @memberof EditorExtension
    */
-  public type: ShellExtensionType.EDITOR = ShellExtensionType.EDITOR;
+  public type: ContentExtensionType = ContentExtensionType.EDITOR;
 
   /**
    * Optional settings of the editor extension
@@ -135,7 +125,7 @@ export class EditorExtension extends Extension {
         }
       }
     }
-    if (!this.type || this.type !== ShellExtensionType.EDITOR) {
+    if (!this.type || this.type !== ContentExtensionType.EDITOR) {
       issues.push('Host type  is invalid. Value: ' + this.type);
     }
 

--- a/src/manifest/extensions/shell/ShellExtensionType.ts
+++ b/src/manifest/extensions/shell/ShellExtensionType.ts
@@ -37,11 +37,4 @@ export enum ShellExtensionType {
    * To be used for extensions ike chat etc.
    */
   TOOL = 'shell-tool',
-
-  /**
-   * Editor extension is show as a toolbar of icons extending the editor
-   * with a set of 3rd party tools which are loaded in a iframe popup
-   * once editor user clicks on some of the icons.
-   */
-  EDITOR = 'shell-editor',
 }


### PR DESCRIPTION
Per review comment, creating dedicated enum for editor extension type so it will change from "shell-editor" to "content-editor"

