### PR TITLE
[oree-883] Restoring depricated external property on account, prospect and opportunity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outreach/extensibility-sdk",
   "license": "MIT",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "private": false,
   "contributors": [
     "Outreach Client Extensibility Team <cxt-sdk@outreach.io>"

--- a/src/context/host/AccountContext.ts
+++ b/src/context/host/AccountContext.ts
@@ -23,6 +23,13 @@ export class AccountContext extends CustomContext implements IAccountContext {
 
   tags?: string | null;
 
+  /**
+   * A collection of external plugin providers given opportunity has
+   *
+   * @type {ExternalInfoContext[]}
+   * @memberof ProspectContext
+   *  @deprecated use externalProviderId and externalProviderName instead
+   */
   externalInfo: ExternalInfoContext[] = [];
 
   /**

--- a/src/context/host/AccountContextUtils.ts
+++ b/src/context/host/AccountContextUtils.ts
@@ -1,6 +1,7 @@
 import { AccountContextKeys } from '../keys/AccountContextKeys';
 import { ContextParam } from './ContextParam';
 import { AccountContext } from './AccountContext';
+import { ExternalInfoUtils } from './ExternalInfoUtils';
 
 export const initAccountContext = (context: AccountContext, param: ContextParam): boolean => {
   switch (param.key) {
@@ -480,6 +481,9 @@ export const initAccountContext = (context: AccountContext, param: ContextParam)
       break;
     case AccountContextKeys.CUSTOM_FIELD_150:
       context.customField150 = param.value;
+      break;
+    case AccountContextKeys.EXTERNAL:
+      context.externalInfo = param.value ? ExternalInfoUtils.unpack(param.value) : [];
       break;
     default:
       return false;
@@ -1600,5 +1604,13 @@ export const toAccountParams = (context: AccountContext): ContextParam[] => {
       value: context.customField150,
     });
   }
+
+  if (context.externalInfo) {
+    params.push({
+      key: AccountContextKeys.EXTERNAL,
+      value: ExternalInfoUtils.pack(context.externalInfo),
+    });
+  }
+
   return params;
 };

--- a/src/context/host/OpportunityContext.ts
+++ b/src/context/host/OpportunityContext.ts
@@ -27,6 +27,13 @@ export class OpportunityContext extends CustomContext implements IOpportunityCon
 
   tags?: string | null;
 
+  /**
+   * A collection of external plugin providers given opportunity has
+   *
+   * @type {ExternalInfoContext[]}
+   * @memberof ProspectContext
+   *  @deprecated use externalProviderId and externalProviderName instead
+   */
   externalInfo: ExternalInfoContext[] = [];
 
   /**

--- a/src/context/host/OpportunityContextUtils.ts
+++ b/src/context/host/OpportunityContextUtils.ts
@@ -1,5 +1,6 @@
 import { OpportunityContextKeys } from '../keys/OpportunityContextKeys';
 import { ContextParam } from './ContextParam';
+import { ExternalInfoUtils } from './ExternalInfoUtils';
 import { OpportunityContext } from './OpportunityContext';
 
 export const initOpportunityContext = (context: OpportunityContext, param: ContextParam): boolean => {
@@ -490,6 +491,9 @@ export const initOpportunityContext = (context: OpportunityContext, param: Conte
       break;
     case OpportunityContextKeys.CUSTOM_FIELD_150:
       context.customField150 = param.value;
+      break;
+    case OpportunityContextKeys.EXTERNAL:
+      context.externalInfo = param.value ? ExternalInfoUtils.unpack(param.value) : [];
       break;
     default:
       return false;
@@ -1622,6 +1626,13 @@ export const toOpportunityParams = (context: OpportunityContext): ContextParam[]
     params.push({
       key: OpportunityContextKeys.CUSTOM_FIELD_150,
       value: context.customField150,
+    });
+  }
+
+  if (context.externalInfo) {
+    params.push({
+      key: OpportunityContextKeys.EXTERNAL,
+      value: ExternalInfoUtils.pack(context.externalInfo),
     });
   }
 

--- a/src/context/host/ProspectContext.ts
+++ b/src/context/host/ProspectContext.ts
@@ -42,6 +42,13 @@ export class ProspectContext extends CustomContext implements IProspectContext {
 
   title?: string | null;
 
+  /**
+   * A collection of external plugin providers given prospect has
+   *
+   * @type {ExternalInfoContext[]}
+   * @memberof ProspectContext
+   *  @deprecated use externalProviderId and externalProviderName instead
+   */
   externalInfo: ExternalInfoContext[] = [];
 
   /**

--- a/src/context/host/ProspectContextUtils.ts
+++ b/src/context/host/ProspectContextUtils.ts
@@ -1,5 +1,6 @@
 import { ProspectContextKeys } from '../keys/ProspectContextKeys';
 import { ContextParam } from './ContextParam';
+import { ExternalInfoUtils } from './ExternalInfoUtils';
 import { ProspectContext } from './ProspectContext';
 
 export const initProspectContext = (context: ProspectContext, param: ContextParam): boolean => {
@@ -511,6 +512,9 @@ export const initProspectContext = (context: ProspectContext, param: ContextPara
       break;
     case ProspectContextKeys.CUSTOM_FIELD_150:
       context.customField150 = param.value;
+      break;
+    case ProspectContextKeys.EXTERNAL:
+      context.externalInfo = param.value ? ExternalInfoUtils.unpack(param.value) : [];
       break;
     default:
       return false;
@@ -1696,6 +1700,13 @@ export const toProspectParams = (context: ProspectContext): ContextParam[] => {
     params.push({
       key: ProspectContextKeys.CUSTOM_FIELD_150,
       value: context.customField150,
+    });
+  }
+
+  if (context.externalInfo) {
+    params.push({
+      key: ProspectContextKeys.EXTERNAL,
+      value: ExternalInfoUtils.pack(context.externalInfo),
     });
   }
 

--- a/tests/AccountContextUtils.test.ts
+++ b/tests/AccountContextUtils.test.ts
@@ -1,0 +1,55 @@
+import { AccountContext } from '../src/context/host/AccountContext';
+import { initAccountContext, toAccountParams } from '../src/context/host/AccountContextUtils';
+import { ContextParam } from '../src/context/host/ContextParam';
+import { ExternalInfoProvider } from '../src/context/host/ExternalInfoProvider';
+import { AccountContextKeys } from '../src/context/keys/AccountContextKeys';
+
+describe('AccountContextUtils', () => {
+  it('will pack the external info', () => {
+    var ctx = new AccountContext();
+    ctx.externalInfo = [
+      { id: '1', enabled: true, provider: ExternalInfoProvider.SALESFORCE, type: 'type-1', name: 'name-1' },
+      { id: '2', enabled: true, provider: ExternalInfoProvider.DYNAMICS, type: 'type-2', name: 'name-2' },
+    ];
+
+    var params = toAccountParams(ctx);
+
+    expect(params.length).toBe(1);
+    expect(params[0].key).toBe(AccountContextKeys.EXTERNAL);
+    expect(params[0].value).toBe(
+      '[{"e":true,"i":"1","n":"name-1","p":1,"t":"type-1"},{"e":true,"i":"2","n":"name-2","p":2,"t":"type-2"}]'
+    );
+  });
+
+  it('will unpack external info', () => {
+    var ctx = new AccountContext();
+    var params: ContextParam = {
+      key: AccountContextKeys.EXTERNAL,
+      value: '[{"e":true,"i":"1","n":"name-1","p":1,"t":"type-1"},{"e":true,"i":"2","n":"name-2","p":2,"t":"type-2"}]',
+    };
+
+    const result = initAccountContext(ctx, params);
+    expect(result).toBe(true);
+    expect(ctx.externalInfo.length).toBe(2);
+
+    expect(ctx.externalInfo[0]).toEqual({
+      id: '1',
+      enabled: true,
+      provider: ExternalInfoProvider.SALESFORCE,
+      type: 'type-1',
+      name: 'name-1',
+      lastInbound: null,
+      lastOutbound: null,
+    });
+
+    expect(ctx.externalInfo[1]).toEqual({
+      id: '2',
+      enabled: true,
+      provider: ExternalInfoProvider.DYNAMICS,
+      type: 'type-2',
+      name: 'name-2',
+      lastInbound: null,
+      lastOutbound: null,
+    });
+  });
+});

--- a/tests/OpportunityContextUtils.test.ts
+++ b/tests/OpportunityContextUtils.test.ts
@@ -1,0 +1,55 @@
+import { OpportunityContext } from '../src/context/host/OpportunityContext';
+import { initOpportunityContext, toOpportunityParams } from '../src/context/host/OpportunityContextUtils';
+import { ContextParam } from '../src/context/host/ContextParam';
+import { ExternalInfoProvider } from '../src/context/host/ExternalInfoProvider';
+import { OpportunityContextKeys } from '../src/context/keys/OpportunityContextKeys';
+
+describe('OpportunityContextUtils', () => {
+  it('will pack the external info', () => {
+    var ctx = new OpportunityContext();
+    ctx.externalInfo = [
+      { id: '1', enabled: true, provider: ExternalInfoProvider.SALESFORCE, type: 'type-1', name: 'name-1' },
+      { id: '2', enabled: true, provider: ExternalInfoProvider.DYNAMICS, type: 'type-2', name: 'name-2' },
+    ];
+
+    var params = toOpportunityParams(ctx);
+
+    expect(params.length).toBe(1);
+    expect(params[0].key).toBe(OpportunityContextKeys.EXTERNAL);
+    expect(params[0].value).toBe(
+      '[{"e":true,"i":"1","n":"name-1","p":1,"t":"type-1"},{"e":true,"i":"2","n":"name-2","p":2,"t":"type-2"}]'
+    );
+  });
+
+  it('will unpack external info', () => {
+    var ctx = new OpportunityContext();
+    var params: ContextParam = {
+      key: OpportunityContextKeys.EXTERNAL,
+      value: '[{"e":true,"i":"1","n":"name-1","p":1,"t":"type-1"},{"e":true,"i":"2","n":"name-2","p":2,"t":"type-2"}]',
+    };
+
+    const result = initOpportunityContext(ctx, params);
+    expect(result).toBe(true);
+    expect(ctx.externalInfo.length).toBe(2);
+
+    expect(ctx.externalInfo[0]).toEqual({
+      id: '1',
+      enabled: true,
+      provider: ExternalInfoProvider.SALESFORCE,
+      type: 'type-1',
+      name: 'name-1',
+      lastInbound: null,
+      lastOutbound: null,
+    });
+
+    expect(ctx.externalInfo[1]).toEqual({
+      id: '2',
+      enabled: true,
+      provider: ExternalInfoProvider.DYNAMICS,
+      type: 'type-2',
+      name: 'name-2',
+      lastInbound: null,
+      lastOutbound: null,
+    });
+  });
+});

--- a/tests/ProspectContextUtils.test.ts
+++ b/tests/ProspectContextUtils.test.ts
@@ -1,0 +1,55 @@
+import { ProspectContext } from '../src/context/host/ProspectContext';
+import { initProspectContext, toProspectParams } from '../src/context/host/ProspectContextUtils';
+import { ContextParam } from '../src/context/host/ContextParam';
+import { ExternalInfoProvider } from '../src/context/host/ExternalInfoProvider';
+import { ProspectContextKeys } from '../src/context/keys/ProspectContextKeys';
+
+describe('ProspectContextUtils', () => {
+  it('will pack the external info', () => {
+    var ctx = new ProspectContext();
+    ctx.externalInfo = [
+      { id: '1', enabled: true, provider: ExternalInfoProvider.SALESFORCE, type: 'type-1', name: 'name-1' },
+      { id: '2', enabled: true, provider: ExternalInfoProvider.DYNAMICS, type: 'type-2', name: 'name-2' },
+    ];
+
+    var params = toProspectParams(ctx);
+
+    expect(params.length).toBe(1);
+    expect(params[0].key).toBe(ProspectContextKeys.EXTERNAL);
+    expect(params[0].value).toBe(
+      '[{"e":true,"i":"1","n":"name-1","p":1,"t":"type-1"},{"e":true,"i":"2","n":"name-2","p":2,"t":"type-2"}]'
+    );
+  });
+
+  it('will unpack external info', () => {
+    var ctx = new ProspectContext();
+    var params: ContextParam = {
+      key: ProspectContextKeys.EXTERNAL,
+      value: '[{"e":true,"i":"1","n":"name-1","p":1,"t":"type-1"},{"e":true,"i":"2","n":"name-2","p":2,"t":"type-2"}]',
+    };
+
+    const result = initProspectContext(ctx, params);
+    expect(result).toBe(true);
+    expect(ctx.externalInfo.length).toBe(2);
+
+    expect(ctx.externalInfo[0]).toEqual({
+      id: '1',
+      enabled: true,
+      provider: ExternalInfoProvider.SALESFORCE,
+      type: 'type-1',
+      name: 'name-1',
+      lastInbound: null,
+      lastOutbound: null,
+    });
+
+    expect(ctx.externalInfo[1]).toEqual({
+      id: '2',
+      enabled: true,
+      provider: ExternalInfoProvider.DYNAMICS,
+      type: 'type-2',
+      name: 'name-2',
+      lastInbound: null,
+      lastOutbound: null,
+    });
+  });
+});


### PR DESCRIPTION
Restoring back removed deprecated property for external provider information as it is needed for backward compatibility 