### PR TITLE
[OREE-903] Mailing links data extension

### DIFF
--- a/src/context/keys/AllContextKeys.ts
+++ b/src/context/keys/AllContextKeys.ts
@@ -5,6 +5,7 @@ import { OpportunityContextKeys } from './OpportunityContextKeys';
 import { ClientContextKeys } from './ClientContextKeys';
 import { ProspectContextKeys } from './ProspectContextKeys';
 import { OrganizationContextKeys } from './OrganizationContextKeys';
+import { UnknownContextKeys } from './UnknownContextKeys';
 
 export type AllContextKeys =
   | UserContextKeys
@@ -12,4 +13,5 @@ export type AllContextKeys =
   | AccountContextKeys
   | OpportunityContextKeys
   | ClientContextKeys
-  | ProspectContextKeys;
+  | ProspectContextKeys
+  | UnknownContextKeys;

--- a/src/context/keys/UnknownContextKeys.ts
+++ b/src/context/keys/UnknownContextKeys.ts
@@ -1,0 +1,10 @@
+/**
+ * An empty enum used for extensions not having any context
+ *
+ * @export
+ * @enum {number}
+ */
+export enum UnknownContextKeys {
+  // eslint-disable-next-line no-unused-vars
+  UNKNOWN = 'unk.nop',
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -153,6 +153,8 @@ export { EditorRegion } from './manifest/extensions/editor/EditorRegion';
 export { EditorSize } from './manifest/extensions/editor/EditorSize';
 export { ManifestTranslator } from './legacy/ManifestTranslator';
 
+export { MailingLinksDataExtension } from './manifest/extensions/data/MailingLinksDataExtension';
+
 export {
   isDecorationMessage,
   isEnvironmentMessage,

--- a/src/legacy/ManifestTranslator.ts
+++ b/src/legacy/ManifestTranslator.ts
@@ -133,7 +133,7 @@ export class ManifestTranslator {
       context: ext.context.map((c) => c.toString()),
       description: app.store.description,
       host: {
-        icon: ext.host.icon,
+        icon: ext.host instanceof ShellExtensionHost ? ext.host.icon : '',
         url: ext.host.url!,
         notificationsUrl: ext.host instanceof ShellExtensionHost ? ext.host.notificationsUrl || '' : '',
         type: manifestType,
@@ -230,9 +230,12 @@ export class ManifestTranslator {
 
       extension.identifier = ext.identifier;
       extension.title = ext.title;
-      extension.host.icon = ext.host.icon;
       extension.host.url = ext.host.url;
       extension.version = ext.version;
+
+      if (extension.host instanceof ShellExtensionHost) {
+        extension.host.icon = ext.host.icon;
+      }
 
       return extension;
     });

--- a/src/manifest/extensions/ExtensionHost.ts
+++ b/src/manifest/extensions/ExtensionHost.ts
@@ -14,14 +14,4 @@ export class ExtensionHost {
    * @memberof ExtensionHost
    */
   url?: string;
-
-  /**
-   * Base64 string represents the icon to be shown in the addon store
-   * and (if applicable) in the Outreach app.
-   *
-   * @see https://github.com/getoutreach/extensibility-sdk/blob/master/docs/manifest.md#icon
-   * @type {string}
-   * @memberof ExtensionHost
-   */
-  icon: string;
 }

--- a/src/manifest/extensions/ExtensionType.ts
+++ b/src/manifest/extensions/ExtensionType.ts
@@ -1,3 +1,5 @@
+import { DataExtensionType } from './data/DataExtensionType';
+import { MailingLinksDataExtension } from './data/MailingLinksDataExtension';
 import { ContentExtensionType } from './editor/ContentExtensionType';
 import { ShellExtensionType } from './shell/ShellExtensionType';
 import { ActionShellExtension } from './shell/types/ActionShellExtension';
@@ -16,7 +18,12 @@ import { AccountTileExtension } from './tiles/types/AccountTileExtension';
 import { OpportunityTileExtension } from './tiles/types/OpportunityTileExtension';
 import { ProspectTileExtension } from './tiles/types/ProspectTileExtension';
 
-export type ExtensionType = TabExtensionType | TileExtensionType | ShellExtensionType | ContentExtensionType;
+export type ExtensionType =
+  | TabExtensionType
+  | TileExtensionType
+  | ShellExtensionType
+  | ContentExtensionType
+  | DataExtensionType;
 
 export type ProspectExtensionType =
   | TabExtensionType.PROSPECT
@@ -48,5 +55,7 @@ export type AppExtension =
   | SidekickShellExtension
   | ToolShellExtension
   | ActionShellExtension;
+
+export type DataExtension = MailingLinksDataExtension;
 
 export type GeneralExtension = AppExtension | ReportsTabExtension;

--- a/src/manifest/extensions/data/DataExtension.ts
+++ b/src/manifest/extensions/data/DataExtension.ts
@@ -1,0 +1,37 @@
+import { Extension } from '../Extension';
+
+import { OutreachContext } from '../../../context/OutreachContext';
+import { DataExtensionType } from './DataExtensionType';
+import { UnknownContextKeys } from '../../../context/keys/UnknownContextKeys';
+
+export abstract class DataExtension extends Extension {
+  /**
+   * Data extensions are not supporting any contextual properties
+   *
+   * @see https://github.com/getoutreach/extensibility-sdk/blob/master/docs/manifest.md#context
+   * @see https://github.com/getoutreach/extensibility-sdk/blob/master/docs/context.md
+   *  @type {UnknownContextKeys[]}
+   * @memberof DataExtension
+   */
+  public context: UnknownContextKeys[];
+
+  /**
+   * Type property defines the type of tab extension
+   * @see https://github.com/getoutreach/extensibility-sdk/blob/master/docs/manifest.md#type
+   * @type {DataExtensionType}
+   * @memberof DataExtension
+   */
+  public type!: DataExtensionType;
+
+  /**
+   * Initialize Outreach context with contextual information.
+   *
+   * @param {OutreachContext} context
+   * @return {*}  {boolean}
+   * @memberof DataExtension
+   */
+  init(_: OutreachContext): boolean {
+    // NOTE: nimal, 10/12/22 - Data extensions are not initialized with context
+    return false;
+  }
+}

--- a/src/manifest/extensions/data/DataExtensionType.ts
+++ b/src/manifest/extensions/data/DataExtensionType.ts
@@ -1,0 +1,15 @@
+/* eslint-disable no-unused-vars */
+
+/**
+ * List of supported data extension types.
+ * @see https://github.com/getoutreach/extensibility-sdk/blob/master/docs/manifest.md#type
+ * @export
+ * @enum {number}
+ */
+export enum DataExtensionType {
+
+    /**
+     * Data extension providing server side replacing of the email links
+     */
+    MAILING_LINKS = 'data-mailing-links',
+}

--- a/src/manifest/extensions/data/MailingLinksDataExtension.ts
+++ b/src/manifest/extensions/data/MailingLinksDataExtension.ts
@@ -1,0 +1,65 @@
+import { UnknownContextKeys } from '../../../context/keys/UnknownContextKeys';
+import { utils } from '../../../utils';
+import { DataExtension } from './DataExtension';
+import { DataExtensionType } from './DataExtensionType';
+
+export class MailingLinksDataExtension extends DataExtension {
+  /**
+   * Type of mailing link data extension
+   * @see https://github.com/getoutreach/extensibility-sdk/blob/master/docs/manifest.md#type
+   * @type {DataExtensionType}
+   * @memberof MailingLinksDataExtension
+   */
+  public type: DataExtensionType.MAILING_LINKS = DataExtensionType.MAILING_LINKS;
+
+  /**
+   * Definition of hosting section
+   *
+   * @type {{ url: string }}
+   * @memberof MailingLinksDataExtension
+   */
+  public host: { url: string };
+
+  /**
+   * Validates the data extension configuration
+   *
+   * @param {Application} application
+   * @return {*}  {string[]}
+   * @memberof MailingLinksDataExtension
+   */
+  validate(): string[] {
+    const issues: string[] = [];
+
+    if (!this.host) {
+      issues.push('Host section is missing.');
+    } else {
+      if (!this.host.url) {
+        issues.push('Host url definition is missing.');
+      } else {
+        if (!utils.hostUrlValidation(this.host.url, this.context)) {
+          issues.push('Host url is invalid. Value: ' + this.host.url);
+        }
+      }
+
+      if (!this.type || !Object.values(DataExtensionType).includes(this.type as DataExtensionType)) {
+        issues.push('Host type  is invalid. Value: ' + this.type);
+      }
+    }
+
+    if (!this.context) {
+      issues.push('Context section is missing');
+    } else {
+      if (!Array.isArray(this.context)) {
+        issues.push('Context section is not an array. Value: ' + this.context);
+      }
+
+      this.context.forEach((context) => {
+        if (!Object.values(UnknownContextKeys).includes(context as UnknownContextKeys)) {
+          issues.push('Context key is not one of the valid values for the data extension. Key: ' + context);
+        }
+      });
+    }
+
+    return issues;
+  }
+}

--- a/src/manifest/extensions/editor/EditorExtension.ts
+++ b/src/manifest/extensions/editor/EditorExtension.ts
@@ -11,6 +11,7 @@ import { ClientContextKeys } from '../../../context/keys/ClientContextKeys';
 import { OrganizationContextKeys } from '../../../context/keys/OrganizationContextKeys';
 import { EditorSettings } from './EditorSettings';
 import { ContentExtensionType } from './ContentExtensionType';
+import { EditorExtensionHost } from './EditorExtensionHost';
 
 export class EditorExtension extends Extension {
   /**
@@ -32,6 +33,14 @@ export class EditorExtension extends Extension {
    * @memberof EditorExtension
    */
   public type: ContentExtensionType = ContentExtensionType.EDITOR;
+
+  /**
+   * Editor extension host section definition
+   *
+   * @type {EditorExtensionHost}
+   * @memberof EditorExtension
+   */
+  public host!: EditorExtensionHost;
 
   /**
    * Optional settings of the editor extension

--- a/src/manifest/extensions/editor/EditorExtensionHost.ts
+++ b/src/manifest/extensions/editor/EditorExtensionHost.ts
@@ -1,0 +1,13 @@
+import { ExtensionHost } from '../ExtensionHost';
+
+export class EditorExtensionHost extends ExtensionHost {
+  /**
+   * Base64 string represents the icon to be shown in the addon store
+   * and (if applicable) in the Outreach app.
+   *
+   * @see https://github.com/getoutreach/extensibility-sdk/blob/master/docs/manifest.md#icon
+   * @type {string}
+   * @memberof TileExtensionHost
+   */
+  icon: string;
+}

--- a/src/manifest/extensions/shell/ShellExtensionHost.ts
+++ b/src/manifest/extensions/shell/ShellExtensionHost.ts
@@ -10,6 +10,16 @@ import { DecorationStyle } from './DecorationStyle';
  */
 export class ShellExtensionHost extends ExtensionHost {
   /**
+   * Base64 string represents the icon to be shown in the addon store
+   * and (if applicable) in the Outreach app.
+   *
+   * @see https://github.com/getoutreach/extensibility-sdk/blob/master/docs/manifest.md#icon
+   * @type {string}
+   * @memberof ShellExtensionHost
+   */
+  icon: string;
+
+  /**
    * Optional address of the endpoint serving notification centric version of the addon experience.
    *
    * If defined, this endpoint will serve an empty HTML page with SDK on it, and the Outreach app

--- a/src/manifest/extensions/tabs/TabExtension.ts
+++ b/src/manifest/extensions/tabs/TabExtension.ts
@@ -88,10 +88,6 @@ export class TabExtension extends Extension {
     if (!this.host) {
       issues.push('Host section is missing.');
     } else {
-      if (!utils.urlValidation(this.host.icon)) {
-        issues.push('Host icon definition is invalid url. Value: ' + this.host.icon);
-      }
-
       if (!this.host.url) {
         issues.push('Host url definition is missing.');
       } else {

--- a/src/manifest/extensions/tiles/TileExtensionHost.ts
+++ b/src/manifest/extensions/tiles/TileExtensionHost.ts
@@ -9,6 +9,16 @@ import { ExtensionHost } from '../ExtensionHost';
  */
 export class TileExtensionHost extends ExtensionHost {
   /**
+   * Base64 string represents the icon to be shown in the addon store
+   * and (if applicable) in the Outreach app.
+   *
+   * @see https://github.com/getoutreach/extensibility-sdk/blob/master/docs/manifest.md#icon
+   * @type {string}
+   * @memberof TileExtensionHost
+   */
+  icon: string;
+
+  /**
    * A react component to be used for rendering the tile.
    * This is primarily reserved for 1st party tile extensions
    * due to the security context in which such component runs.

--- a/tests/mailingLinksDataExtension.test.ts
+++ b/tests/mailingLinksDataExtension.test.ts
@@ -1,0 +1,49 @@
+import { MailingLinksDataExtension } from '../src';
+
+describe('MailingLinksDataExtension', () => {
+  describe('host', () => {
+    test('host has to be defined', () => {
+      const ext = getValidExtension();
+      delete (ext as any).host;
+      var issues = ext.validate();
+      expect(issues.length).toBe(1);
+      expect(issues[0]).toBe('Host section is missing.');
+    });
+
+    test('host.url - has to be defined', () => {
+      const ext = getValidExtension();
+      delete (ext.host as any).url;
+      var issues = ext.validate();
+      expect(issues.length).toBe(1);
+      expect(issues[0]).toBe('Host url definition is missing.');
+    });
+
+    test('host.url - only url should be acceptable', () => {
+      const ext = getValidExtension();
+      ext.host.url = 'BANANAS';
+      var issues = ext.validate();
+      expect(issues.length).toBe(1);
+      expect(issues[0]).toBe('Host url is invalid. Value: BANANAS');
+    });
+
+    test('only valid type should be acceptable', () => {
+      const ext = getValidExtension();
+      ext.type = 'BANANAS' as any;
+      var issues = ext.validate();
+      expect(issues.length).toBe(1);
+      expect(issues[0]).toBe('Host type  is invalid. Value: BANANAS');
+    });
+  });
+});
+
+const getValidExtension = (): MailingLinksDataExtension => {
+  var ext = new MailingLinksDataExtension();
+  ext.identifier = 'data-mail-links';
+  ext.host = {
+    url: 'http://someurl.com/host',
+  };
+  ext.version = '0.99';
+  ext.context = [];
+
+  return ext;
+};

--- a/tests/tabExtension.test.ts
+++ b/tests/tabExtension.test.ts
@@ -55,14 +55,6 @@ describe('TabExension validate tests', () => {
       expect(issues.length).toBe(0);
     });
 
-    test('host.icon - only url should be acceptable', () => {
-      const tabExtension = getValidOpportunityTabExtension();
-      tabExtension.host.icon = 'bananas';
-      var issues = tabExtension.validate();
-      expect(issues.length).toBe(1);
-      expect(issues[0]).toBe('Host icon definition is invalid url. Value: bananas');
-    });
-
     test('only valid type should be acceptable', () => {
       const tabExtension = getValidOpportunityTabExtension() as TabExtension;
       tabExtension.type = 'BANANAS' as any;
@@ -107,7 +99,6 @@ const getValidOpportunityTabExtension = (): OpportunityTabExtension => {
   tabExtension.identifier = 'opportunity-tab-addon';
   tabExtension.fullWidth = false;
   tabExtension.host = {
-    icon: 'http://someurl.com/favicon.png',
     url: 'http://someurl.com/host',
   };
   tabExtension.version = '0.99';

--- a/tests/translator.test.ts
+++ b/tests/translator.test.ts
@@ -63,7 +63,6 @@ describe('Manifest translator tests', () => {
     ]);
     expect(tabProspectExt.description).toBe(v1Manifests[0].description);
     expect(tabProspectExt.fullWidth).toBe(v1Manifests[0].host.environment.fullWidth);
-    expect(tabProspectExt.host.icon).toBe(v1Manifests[0].host.icon);
     expect(tabProspectExt.host.url).toBe(v1Manifests[0].host.url);
     expect(tabProspectExt.identifier).toBe(v1Manifests[0].identifier);
     expect(tabProspectExt.title).toBe(v1Manifests[0].title);
@@ -92,7 +91,6 @@ describe('Manifest translator tests', () => {
     ]);
     expect(tabOpportunityExt.description).toBe(v1Manifests[2].description);
     expect(tabOpportunityExt.fullWidth).toBe(v1Manifests[2].host.environment.fullWidth);
-    expect(tabOpportunityExt.host.icon).toBe(v1Manifests[2].host.icon);
     expect(tabOpportunityExt.host.url).toBe(v1Manifests[2].host.url);
     expect(tabOpportunityExt.identifier).toBe(v1Manifests[2].identifier);
     expect(tabOpportunityExt.title).toBe(v1Manifests[2].title);


### PR DESCRIPTION
Support for mailing links data extension.

Highlights: 
- Icon property is moved out from ExtensionHost (not all extensions are having icons)
- New data extension type introduced for extensions providing data integration scenarios