### PR TITLE
[OREE-852] Add context keys needed for content editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outreach/extensibility-sdk",
   "license": "MIT",
-  "version": "0.6.5",
+  "version": "0.6.6",
   "private": false,
   "contributors": [
     "Outreach Client Extensibility Team <cxt-sdk@outreach.io>"

--- a/src/context/keys/ClientContextKeys.ts
+++ b/src/context/keys/ClientContextKeys.ts
@@ -21,4 +21,14 @@ export enum ClientContextKeys {
    * use to reneder itself to
    */
   THEME = 'theme',
+
+  /**
+   * Install ID for Galaxy Apps backwards compatibility
+   */
+  INSTALL_ID = 'installId',
+
+  /**
+   * Context host for Text Editor extension and Galaxy backwards compatibility
+   */
+  CONTEXT_HOST = 'contextHost',
 }


### PR DESCRIPTION
To pass these query parameters to the iframe in TextEditor, their keys have to be defined and allowed.