### PR TITLE
[OREE-861] Expanding editor extension context

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outreach/extensibility-sdk",
   "license": "MIT",
-  "version": "0.6.82",
+  "version": "0.6.83",
   "private": false,
   "contributors": [
     "Outreach Client Extensibility Team <cxt-sdk@outreach.io>"

--- a/src/manifest/extensions/editor/EditorExtension.ts
+++ b/src/manifest/extensions/editor/EditorExtension.ts
@@ -12,6 +12,9 @@ import { OrganizationContextKeys } from '../../../context/keys/OrganizationConte
 import { EditorSettings } from './EditorSettings';
 import { ContentExtensionType } from './ContentExtensionType';
 import { EditorExtensionHost } from './EditorExtensionHost';
+import { ProspectContextKeys } from '../../../context/keys/ProspectContextKeys';
+import { OpportunityContextKeys } from '../../../context/keys/OpportunityContextKeys';
+import { AccountContextKeys } from '../../../context/keys/AccountContextKeys';
 
 export class EditorExtension extends Extension {
   /**
@@ -21,10 +24,17 @@ export class EditorExtension extends Extension {
    *
    * @see https://github.com/getoutreach/extensibility-sdk/blob/master/docs/manifest.md#context
    * @see https://github.com/getoutreach/extensibility-sdk/blob/master/docs/context.md
-   *  @type {(UserContextKeys | ClientContextKeys | OrganizationContextKeys)[]}
+   *  @type {(UserContextKeys | ClientContextKeys | OrganizationContextKeys | ProspectContextKeys | OpportunityContextKeys | AccountContextKeys)[]}
    * @memberof EditorExtension
    */
-  public context: (UserContextKeys | ClientContextKeys | OrganizationContextKeys)[];
+  public context: (
+    | UserContextKeys
+    | ClientContextKeys
+    | OrganizationContextKeys
+    | ProspectContextKeys
+    | OpportunityContextKeys
+    | AccountContextKeys
+  )[];
 
   /**
    * Type property defines the type of tab extension


### PR DESCRIPTION
[OREE-861]

Editor content extension can receive additional account/prospect/opportunity properties in some scenarios. 

[OREE-861]: https://outreach-io.atlassian.net/browse/OREE-861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ