### PR TITLE
fix: manifest schema made actually usable in orexservice

### DIFF
--- a/docs/schema/2.0/manifest.schema.json
+++ b/docs/schema/2.0/manifest.schema.json
@@ -162,6 +162,9 @@
           },
           "uniqueItems": true
         },
+        "scopesAll": {
+          "type": "boolean"
+        },
         "redirectUris": {
           "type": "array",
           "items": {

--- a/docs/schema/2.0/manifest.schema.json
+++ b/docs/schema/2.0/manifest.schema.json
@@ -2,6 +2,12 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://github.com/getoutreach/extensibility-sdk/docs/schema/2.0/manifest.schema.json",
   "properties": {
+    "identifier": {
+      "type": "string",
+      "minLength": 6,
+      "maxLength": 128,
+      "pattern": "^[a-z0-9_-]+$"
+    },
     "store": {
       "type": "object",
       "properties": {
@@ -37,24 +43,25 @@
         "categories": {
           "type": "array",
           "items": {
-            "type": "string"
+            "type": "string",
+            "enum": [
+              "account_based_marketing",
+              "chat",
+              "conversation_intelligence",
+              "crm",
+              "direct_mail",
+              "inbox",
+              "integration_platform",
+              "marketing",
+              "privacy_security",
+              "sales_assets_management",
+              "sales_intelligence_data",
+              "sales_productivity",
+              "video",
+              "voice"
+            ]
           },
-          "enum": [
-            "account_based_marketing",
-            "chat",
-            "conversation_intelligence",
-            "crm",
-            "direct_mail",
-            "inbox",
-            "integration_platform",
-            "marketing",
-            "privacy_security",
-            "sales_assets_management",
-            "sales_intelligence_data",
-            "sales_productivity",
-            "video",
-            "voice"
-          ]
+          "uniqueItems": true
         },
         "description": {
           "type": "object",
@@ -77,18 +84,6 @@
         "iconUrl": {
           "type": "string",
           "format": "uri"
-        },
-        "identifier": {
-          "type": "string",
-          "minLength": 6,
-          "maxLength": 128,
-          "pattern": "^[a-zA-Z0-9._-]+$"
-        },
-        "locales": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
         },
         "medias": {
           "type": "array",
@@ -124,7 +119,7 @@
           "maxLength": 64
         }
       },
-      "required": ["author", "headline", "description", "icon", "identifier", "title", "version"]
+      "required": ["author", "headline", "description", "icon", "title"]
     },
     "webhook": {
       "type": "object",
@@ -137,10 +132,13 @@
           "type": "array",
           "items": {
             "type": "string",
-            "enum": ["install", "uninstall", "setup"]
-          }
+            "enum": ["INSTALL", "UNINSTALL", "SETUP"]
+          },
+          "minItems": 1,
+          "uniqueItems": true
         }
-      }
+      },
+      "required": ["url", "events"]
     },
     "api": {
       "type": "object",
@@ -149,7 +147,8 @@
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "uniqueItems": true
         },
         "redirectUris": {
           "type": "array",
@@ -165,32 +164,40 @@
             }
           }
         }
-      }
+      },
+      "required": ["scopes", "redirectUris", "client"]
     },
     "apiS2S": {
-      "scopes": {
-        "type": "array",
-        "items": {
-          "type": "string"
-        }
-      },
-      "guid": {
-        "type": "string"
-      },
-      "publicKeys": {
-        "type": "array",
-        "items": {
-          "type": "object",
-          "properties": {
-            "name": {
-              "type": "string"
-            },
-            "value": {
-              "type": "string"
-            }
+      "type": "object",
+      "properties": {
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
           }
+        },
+        "guid": {
+          "type": "string",
+          "format": "uuid"
+        },
+        "publicKeys": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "value": {
+                "type": "string"
+              }
+            }
+          },
+          "minItems": 1,
+          "uniqueItems": true
         }
-      }
+      },
+      "required": ["scopes", "publicKeys", "guid"]
     },
     "externalInstallationUrl": {
       "type": "string",
@@ -350,9 +357,9 @@
             }
           }
         },
-        "required": ["identifier", "type", "version", "host", "environment"]
+        "required": ["type"]
       }
     }
   },
-  "required": ["store", "extensions"]
+  "required": ["identifier", "store"]
 }

--- a/docs/schema/2.0/manifest.schema.json
+++ b/docs/schema/2.0/manifest.schema.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://github.com/getoutreach/extensibility-sdk/docs/schema/2.0/manifest.schema.json",
+  "additionalProperties": false,
   "properties": {
     "identifier": {
       "type": "string",
@@ -10,9 +11,11 @@
     },
     "store": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "author": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "company": {
               "type": "string"
@@ -85,10 +88,17 @@
           "type": "string",
           "format": "uri"
         },
+        "locales": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "medias": {
           "type": "array",
           "items": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
               "title": {
                 "type": "string"
@@ -123,6 +133,7 @@
     },
     "webhook": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "url": {
           "type": "string",
@@ -142,6 +153,7 @@
     },
     "api": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "scopes": {
           "type": "array",
@@ -156,19 +168,15 @@
             "type": "string"
           }
         },
-        "client": {
-          "type": "object",
-          "properties": {
-            "id": {
-              "type": "string"
-            }
-          }
+        "clientId": {
+          "type": "string"
         }
       },
-      "required": ["scopes", "redirectUris", "client"]
+      "required": ["scopes", "redirectUris", "clientId"]
     },
     "apiS2S": {
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "scopes": {
           "type": "array",
@@ -184,6 +192,7 @@
           "type": "array",
           "items": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
               "name": {
                 "type": "string"
@@ -207,10 +216,14 @@
       "type": "string",
       "format": "uri"
     },
+    "disableTimeoutMonitoring": {
+      "type": "boolean"
+    },
     "configuration": {
       "type": "array",
       "items": {
         "type": "object",
+        "additionalProperties": false,
         "properties": {
           "key": {
             "type": "string"
@@ -242,7 +255,21 @@
           "options": {
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "text": {
+                  "type": "object",
+                  "properties": {
+                    "en": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "value": {
+                  "type": "string"
+                }
+              }
             }
           }
         },
@@ -253,6 +280,7 @@
       "type": "array",
       "items": {
         "type": "object",
+        "additionalProperties": false,
         "properties": {
           "version": {
             "type": "string",
@@ -262,6 +290,24 @@
           "identifier": {
             "type": "string",
             "maxLength": 128
+          },
+          "title": {
+            "type": "object",
+            "properties": {
+              "en": {
+                "type": "string"
+              }
+            },
+            "required": ["en"]
+          },
+          "description": {
+            "type": "object",
+            "properties": {
+              "en": {
+                "type": "string"
+              }
+            },
+            "required": ["en"]
           },
           "type": {
             "type": "string",
@@ -291,8 +337,12 @@
               "data-prospect-events"
             ]
           },
+          "fullWidth": {
+            "type": "boolean"
+          },
           "host": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
               "url": {
                 "type": "string",
@@ -316,17 +366,14 @@
               },
               "event": {
                 "type": "string"
-              }
-            }
-          },
-          "environment": {
-            "type": "object",
-            "properties": {
-              "fullWidth": {
-                "type": "boolean"
               },
               "decoration": {
-                "type": "string"
+                "type": "string",
+                "enum": ["none", "full", "simple"]
+              },
+              "notificationsUrl": {
+                "type": "string",
+                "format": "uri"
               }
             }
           },
@@ -338,11 +385,13 @@
           },
           "settings": {
             "type": "object",
+            "additionalProperties": false,
             "properties": {
               "recommended": {
                 "type": "array",
                 "items": {
                   "type": "object",
+                  "additionalProperties": false,
                   "properties": {
                     "width": {
                       "type": "number"


### PR DESCRIPTION
we were not enforcing schema at all in orexservice
with these fixes it can be used to really validate uploaded schema server-side (with a few exceptions)
changes
- identifer is in root, not store
- categories enum must be inside items
- unique values enforced in array where possible
- required fields updated a bit but this conditions is ignored in orexservice as manifests are being saved half-empty and validated before publishing
- apiS2S updated to proper schema format
- additional properties are not allowed (unless it's localized text)