### PR TITLE
update manifest's identifier format and version

### DIFF
--- a/docs/schema/2.0/manifest.schema.json
+++ b/docs/schema/2.0/manifest.schema.json
@@ -7,7 +7,7 @@
       "type": "string",
       "minLength": 6,
       "maxLength": 128,
-      "pattern": "^[a-z0-9_-]+$"
+      "pattern": "^[a-z0-9][a-z0-9-_]+[a-z0-9]$"
     },
     "store": {
       "type": "object",
@@ -125,7 +125,7 @@
         },
         "version": {
           "type": "string",
-          "pattern": "^[0-9]+\\.[0-9]+$",
+          "pattern": "^[0-9]+(\\.[0-9]+)?$",
           "maxLength": 64
         }
       },
@@ -285,13 +285,9 @@
         "type": "object",
         "additionalProperties": false,
         "properties": {
-          "version": {
-            "type": "string",
-            "pattern": "^[0-9]+\\.[0-9]+$",
-            "maxLength": 64
-          },
           "identifier": {
             "type": "string",
+            "pattern": "^[a-z0-9][a-z0-9-_]+[a-z0-9]$",
             "maxLength": 128
           },
           "title": {


### PR DESCRIPTION
- identifier should not start/end with `-`
- version can be single number
- there is no extension version
- extension identifier must not contain `:` (same rules as for app identifier)