### PR TITLE
fix: schema: Update host url type

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -137,7 +137,7 @@ As you can see in the example above, the clientId value is an example of the val
 will need it very early. The url used for loading will have an additional parameter for clientId
 
 ```http
-http://some-site.com/application?...&clientId=a12345
+https://some-site.com/application?...&clientId=a12345
 ```
 
 #### SDK support

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -150,8 +150,8 @@ opportunity tab extension.
         "decoration": "none"
       },
       "host": {
-        "icon": "http://someurl.com/favicon.png",
-        "url": "http://someurl.com/host/app",
+        "icon": "https://someurl.com/favicon.png",
+        "url": "https://someurl.com/host/app",
         "notificationsUrl": "https://addon-host.com/notification"
       },
       "type": "shell-application"
@@ -164,8 +164,8 @@ opportunity tab extension.
         "decoration": "none"
       },
       "host": {
-        "icon": "http://someurl.com/favicon.png",
-        "url": "http://someurl.com/host/opp"
+        "icon": "https://someurl.com/favicon.png",
+        "url": "https://someurl.com/host/opp"
       },
       "type": "tab-opportunity"
     }
@@ -470,14 +470,14 @@ contextual parameters as query parameters.
 e.g.
 
 ```javascript
-manifest.host.url = 'http://somesite.com/something';
+manifest.host.url = 'https://somesite.com/something';
 manifest.context = ['opp.id', 'usr.id'];
 ```
 
 In the case of an Outreach user with id 456 looking at opportunity 123, this will result during the runtime.
 
 ```bash
- http://somesite.com/something?opp.id=123&usr.id=456
+ https://somesite.com/something?opp.id=123&usr.id=456
 ```
 
 In addition to this default behavior, the application creator can customize how the URL is constructed by applying
@@ -486,13 +486,13 @@ simple templatization in addition to this default behavior.
 e.g.
 
 ```javascript
-manifest.host.url = 'http://somesite.com/something/{usr.id}';
+manifest.host.url = 'https://somesite.com/something/{usr.id}';
 ```
 
 will become during the runtime
 
 ```bash
-http://somesite.com/something/456?opp.id=123
+https://somesite.com/something/456?opp.id=123
 ```
 
 > _NB: as opp.id was not tokenized, it was appended as query parameter following the default naming convention_
@@ -502,13 +502,13 @@ The application creator can templatize the name of the query parameters.
 e.g.
 
 ```javascript
-manifest.host.url = 'http://somesite.com/something/{usr.id}?oid={opp.id}';
+manifest.host.url = 'https://somesite.com/something/{usr.id}?oid={opp.id}';
 ```
 
 will become during the runtime
 
 ```bash
-http://somesite.com/something/456?oid=123
+https://somesite.com/something/456?oid=123
 ```
 
 #### icon (of extension)

--- a/docs/schema/2.0/manifest.schema.json
+++ b/docs/schema/2.0/manifest.schema.json
@@ -354,7 +354,7 @@
             "properties": {
               "url": {
                 "type": "string",
-                "format": "uri"
+                "format": "uri-template"
               },
               "component": {
                 "type": "string"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outreach/extensibility-sdk",
   "license": "MIT",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "private": false,
   "contributors": [
     "Outreach Client Extensibility Team <cxt-sdk@outreach.io>"


### PR DESCRIPTION
Make it URI template to allow parameters substitution as described here https://github.com/getoutreach/extensibility-sdk/blob/main/docs/manifest.md#url-host.