### PR TITLE
[OREE-1681] fix: Only log the load warning message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outreach/extensibility-sdk",
   "license": "MIT",
-  "version": "0.9.4",
+  "version": "0.9.5",
   "private": false,
   "contributors": [
     "Outreach Client Extensibility Team <cxt-sdk@outreach.io>"

--- a/src/index.ts
+++ b/src/index.ts
@@ -291,10 +291,13 @@ export class ExtensibilitySdk {
           'error'
         );
       } else if (ctx.loadTime > 2000) {
-        this.notify(
-          `Addon loading takes longer than 2 seconds. Load time:${ctx.loadTime}. Ready time: ${ctx.readyTime}. SessionId: ${sessionId}`,
-          'warning'
-        );
+        logger.current.log({
+          origin: EventOrigin.ADDON,
+          type: EventType.INTERNAL,
+          level: LogLevel.Warning,
+          message: `Addon loading takes longer than 2 seconds. Load time:${ctx.loadTime}. Ready time: ${ctx.readyTime}. SessionId: ${sessionId}`,
+          context: ['Addon loading takes more time than it should'],
+        });
       }
     };
   }


### PR DESCRIPTION
We were sending warning message to the client if the loading time of an addon took more than 2 seconds. Proposed solution was to remove the showing in client and only log it.

After a bit of investigation how does all of this work on client, I found out that we are not blocking any message to come through. I don't feel like cherrypicking one message and blocking it on client is the best solution. It's probably worth to open a discussion on the notifications from SDK in the team once the whole team is together.

Also one there is a one thing where [in client](https://github.com/getoutreach/client/blob/dbf77263eb699d4b15d15a4d0defe7ad172506f6/packages/composites/client-extensibility/src/components/shared/ExtensionArea.tsx#L180) there is a `isTranslatedString` check where it shouldn't show any message that is not translated, but it doesn't work and lets anything through. I already created a [Jira ticket](https://outreach-io.atlassian.net/browse/OREE-1787) to investigate it