### PR TITLE
[OREE-2005] Publish Extensibility SDK into Gihub Packages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
       - run:
           name: Publish NPM package
           command: |
-            npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN
+            npm set //npm.pkg.github.com/:_authToken=$GITHUB_TOKEN
             npm publish
 
 workflows:
@@ -62,6 +62,7 @@ workflows:
       - build_public_package:
           context:
             - npm-credentials
+            - github-credentials
           requires:
             - test
           filters:

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 @outreach:registry=https://registry.npmjs.org/
+@getoutreach:registry=https://npm.pkg.github.com

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@outreach/extensibility-sdk",
+  "name": "@getoutreach/extensibility-sdk",
   "license": "MIT",
-  "version": "0.9.7",
+  "version": "0.10.0",
   "private": false,
   "contributors": [
     "Outreach Client Extensibility Team <cxt-sdk@outreach.io>"


### PR DESCRIPTION
[OREE-2005]

[NPMJS.org](http://npmjs.org/) is deprecated for security reasons at Outreach and we need to move our public extensibility SDK package to Github Packages. See [DT-4053](https://outreach-io.atlassian.net/browse/DT-4053) for more info

A part of that is renaming from `@outreach/extensibility-sdk` to `@getoutreach/extensibility-sdk`

[OREE-2005]: https://outreach-io.atlassian.net/browse/OREE-2005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DT-4053]: https://outreach-io.atlassian.net/browse/DT-4053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ