### PR TITLE
Revert "[OREE-2005] Publish Extensibility SDK into Gihub Packages"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
       - run:
           name: Publish NPM package
           command: |
-            npm set //npm.pkg.github.com/:_authToken=$GITHUB_TOKEN
+            npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN
             npm publish
 
 workflows:
@@ -62,7 +62,6 @@ workflows:
       - build_public_package:
           context:
             - npm-credentials
-            - github-credentials
           requires:
             - test
           filters:

--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 @outreach:registry=https://registry.npmjs.org/
-@getoutreach:registry=https://npm.pkg.github.com

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@getoutreach/extensibility-sdk",
+  "name": "@outreach/extensibility-sdk",
   "license": "MIT",
-  "version": "0.10.0",
+  "version": "0.9.7",
   "private": false,
   "contributors": [
     "Outreach Client Extensibility Team <cxt-sdk@outreach.io>"


### PR DESCRIPTION
Reverts getoutreach/extensibility-sdk#95

We won't switch the public package to GH Packages after all. See [OREE-2005]

[OREE-2005]: https://outreach-io.atlassian.net/browse/OREE-2005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ