### PR TITLE
[OREE-2061] show configuration in outreach context

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@outreach/extensibility-sdk",
   "license": "MIT",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "private": false,
   "contributors": [
     "Outreach Client Extensibility Team <cxt-sdk@outreach.io>"

--- a/src/index.ts
+++ b/src/index.ts
@@ -651,6 +651,7 @@ export class ExtensibilitySdk {
     outreachContext.locale = runtime.locale;
     outreachContext.theme = runtime.theme;
     outreachContext.userIdentifier = runtime.userIdentifier;
+    outreachContext.config = runtime.configuration;
 
     const accountContext = new AccountContext();
     const opportunityContext = new OpportunityContext();

--- a/src/index.ts
+++ b/src/index.ts
@@ -640,7 +640,7 @@ export class ExtensibilitySdk {
   private preprocessInitMessage = (initMessage: InitMessage): OutreachContext => {
     runtime.application = ManifestTranslator.hydrate(initMessage.application);
     runtime.authorizationHost = initMessage.authorizationHost;
-    runtime.configuration = initMessage.configuration;
+    runtime.configuration = { ...initMessage.configuration };
     runtime.extension = initMessage.extension;
     runtime.locale = initMessage.locale;
     runtime.sessionId = initMessage.sessionId;
@@ -651,7 +651,7 @@ export class ExtensibilitySdk {
     outreachContext.locale = runtime.locale;
     outreachContext.theme = runtime.theme;
     outreachContext.userIdentifier = runtime.userIdentifier;
-    outreachContext.config = runtime.configuration;
+    outreachContext.config = { ...runtime.configuration };
 
     const accountContext = new AccountContext();
     const opportunityContext = new OpportunityContext();

--- a/src/legacy/ManifestTranslator.ts
+++ b/src/legacy/ManifestTranslator.ts
@@ -3,7 +3,6 @@ import {
   ActionShellExtension,
   AllContextKeys,
   CompanionShellExtension,
-  ConfigurationItem,
   ContentExtensionType,
   EditorExtension,
   EmailContextKeys,
@@ -307,10 +306,6 @@ export class ManifestTranslator {
 
     if (app.api) {
       application.api = Object.assign(new ManifestApi(), app.api);
-    }
-
-    if (app.configuration) {
-      application.configuration = app.configuration.map((item) => Object.assign(new ConfigurationItem(), item));
     }
 
     application.store = Object.assign(new ManifestStore(), app.store);

--- a/src/legacy/ManifestTranslator.ts
+++ b/src/legacy/ManifestTranslator.ts
@@ -2,6 +2,7 @@ import {
   AccountTileExtension,
   ActionShellExtension,
   AllContextKeys,
+  ConfigurationItem,
   CompanionShellExtension,
   ContentExtensionType,
   EditorExtension,
@@ -309,6 +310,10 @@ export class ManifestTranslator {
     }
 
     application.store = Object.assign(new ManifestStore(), app.store);
+
+    if (app.configuration) {
+      application.configuration = app.configuration.map((item) => Object.assign(new ConfigurationItem(), item));
+    }
 
     application.extensions = app.extensions.map((ext) => {
       switch (ext.type) {

--- a/tests/translator.test.ts
+++ b/tests/translator.test.ts
@@ -1,10 +1,14 @@
 import {
   AccountContextKeys,
+  Application,
   ApplicationShellExtension,
+  Category,
   OpportunityContextKeys,
   OpportunityTabExtension,
   ProspectContextKeys,
   ProspectTabExtension,
+  ScopesS2S,
+  Scopes,
   ShellExtensionType,
   StoreType,
   TabExtensionType,
@@ -13,8 +17,45 @@ import {
 import { ManifestTranslator } from '../src/legacy/ManifestTranslator';
 import { ManifestV1 } from '../src/legacy/ManifestV1';
 import { Locale } from '../src/sdk/Locale';
+import { WebHookEvents } from '../src/manifest/api/WebHookEvents';
 
 describe('Manifest translator tests', () => {
+  test('hydrate works fine', () => {
+    const application = getValidApplication();
+
+    const result = ManifestTranslator.hydrate(application);
+
+    expect(result).not.toBeNull();
+    expect(result).toBeInstanceOf(Application);
+
+    expect(result!.store.author.company).toBe(application.store.author.company);
+    expect(result!.store.author.email).toBe(application.store.author.email);
+    expect(result!.store.author.privacyUrl).toBe(application.store.author.privacyUrl);
+    expect(result!.store.author.websiteUrl).toBe(application.store.author.websiteUrl);
+    expect(result!.store.author.termsOfUseUrl).toBe(application.store.author.termsOfUseUrl);
+
+    expect(result!.store.categories.length).toBe(1);
+    expect(result!.store.description).toEqual(application.store.description);
+    expect(result!.store.headline).toBe(application.store.headline);
+    expect(result!.store.iconUrl).toBe(application.store.iconUrl);
+
+    expect(result!.store.identifier).toBe(application.store.identifier);
+    expect(result!.store.locales).toEqual([Locale.ENGLISH]);
+    expect(result!.store.medias).toEqual(application.store.medias);
+    expect(result!.store.title).toEqual(application.store.title);
+    expect(result!.store.type).toEqual(StoreType.PRIVATE);
+    expect(result!.store.version).toEqual(application.store.version);
+
+    expect(result!.api!.client.id).toBe(application.api!.client.id);
+    expect(result!.api!.scopes).toBe(application.api!.scopes);
+    expect(result!.api!.redirectUris).toEqual(application.api!.redirectUris);
+
+    expect(result!.configuration).toEqual(application.configuration);
+    expect(result!.extensions.length).toBe(2);
+    expect(result!.extensions[1].type).toBe(TabExtensionType.OPPORTUNITY);
+    expect(result!.apiS2S).toBeUndefined();
+  });
+
   test('getAppManifest works fine', () => {
     const result = ManifestTranslator.getAppManifest(v1Manifests);
 
@@ -119,6 +160,13 @@ const v1Manifests = [
       redirectUri: 'https://cxt-demo.azurewebsites.net/authorize',
       applicationId: 'WHnHrLrl1XEBP3liH1YIzVgrWD2xxVcEdr_zmwLGcQ0',
     },
+    configuration: [{
+      key: 'app-configuration',
+      text: { en: 'configuration value' },
+      type: 'string',
+      required: true,
+      urlInclude: false,
+    }],
     host: {
       url: 'https://cxt-demo.azurewebsites.net/addon?type=PROSPECT&param1=abc&param2=xyz',
       icon: 'https://cxt-demo.azurewebsites.net/favicon.png?one',
@@ -127,7 +175,6 @@ const v1Manifests = [
         fullWidth: true,
       },
     },
-    store: 'personal',
     title: {
       en: 'Hello world (OREX)',
       'de-DE': 'German',
@@ -150,7 +197,6 @@ const v1Manifests = [
       'es-LA': 'Spanish',
       'fr-FR': 'French',
     },
-    configuration: [],
   } as ManifestV1,
   {
     api: {
@@ -236,3 +282,108 @@ const v1Manifests = [
     configuration: [],
   } as ManifestV1,
 ];
+
+const getValidApplication = (): Application => {
+  const opportunityTabExtension = new OpportunityTabExtension();
+  opportunityTabExtension.identifier = 'opportunity-tab-addon';
+  opportunityTabExtension.fullWidth = false;
+  opportunityTabExtension.host = {
+    url: 'http://someurl.com/host',
+  };
+  opportunityTabExtension.context = [UserContextKeys.ID, OpportunityContextKeys.ID];
+
+  const appTabExtension = new ApplicationShellExtension();
+  appTabExtension.identifier = 'app-tabaddon';
+  appTabExtension.host = {
+    icon: 'http://someurl.com/favicon.png',
+    url: 'http://someurl.com/host',
+  };
+
+  const application = new Application();
+  application.store = {
+    author: {
+      email: 'author@someurl.com',
+      company: 'Acme ltd',
+      privacyUrl: 'https://someurl.com/privacy',
+      supportUrl: 'https://someurl.com/support',
+      termsOfUseUrl: 'https://someurl.com/tos',
+      websiteUrl: 'https://someurl.com/',
+    },
+    categories: [Category.ACCOUNT_BASED_MARKETING],
+    medias: [
+      {
+        url: 'https://someurl.com/image.png',
+        title: 'Our awesome extension',
+        type: 'image',
+      },
+      {
+        url: 'https://youtube.com/some_video',
+        title: 'Our awesome animation',
+        type: 'video',
+      },
+    ],
+    headline: {
+      en: 'Some headline (en)',
+      'de-DE': 'German',
+      'en-US': 'Hello world (left sidemenu addon)',
+      'es-LA': 'Spanish',
+      'fr-FR': 'French',
+    },
+    description: {
+      en: 'Some description (en)',
+      'de-DE': 'German',
+      'en-US': 'Hello world (left sidemenu addon)',
+      'es-LA': 'Spanish',
+      'fr-FR': 'French',
+    },
+    identifier: 'app-identifier',
+    iconUrl: 'https://someurl.com/icon',
+    locales: [Locale.ENGLISH],
+    type: StoreType.PRIVATE,
+    title: {
+      en: 'Some title (en)',
+      'de-DE': 'German',
+      'en-US': 'Hello world (left sidemenu addon)',
+      'es-LA': 'Spanish',
+      'fr-FR': 'French',
+    },
+    version: '0.10',
+  };
+
+  application.api = {
+    scopes: [Scopes.ACCOUNTS_ALL, Scopes.CALLS_ALL],
+    redirectUris: ['https://addon-host.com/hello-world'],
+    scopesAll: false,
+    client: {
+      id: 'AbCd123456qW',
+    },
+  };
+
+  application.apiS2S = {
+    scopes: [ScopesS2S.ACCOUNTS_ALL, ScopesS2S.CALLS_ALL],
+    publicKeys: [
+      {
+        name: 'My key',
+        value: 'PUBLIC KEY',
+      },
+    ],
+    guid: 'AbCd123456qW',
+  };
+
+  application.webhook = {
+    events: [WebHookEvents.ALL],
+    url: 'https://addon-host.com/webhook',
+  };
+
+  application.configuration = [{
+    key: 'app-configuration',
+    text: { en: 'configuration value' },
+    type: 'string',
+    required: true,
+    urlInclude: false,
+  }],
+
+  application.extensions = [appTabExtension, opportunityTabExtension];
+
+  return application;
+};

--- a/tests/translator.test.ts
+++ b/tests/translator.test.ts
@@ -175,6 +175,7 @@ const v1Manifests = [
         fullWidth: true,
       },
     },
+    store: 'personal',
     title: {
       en: 'Hello world (OREX)',
       'de-DE': 'German',


### PR DESCRIPTION
# [OREE-2061](https://outreach-io.atlassian.net/browse/OREE-2061)

## Description

Applicaiton configuraton is inaccessible in outreach context. This fixes the issue

This line is removed because it messed with the expected output of the outreach context. It expected ConfigurationValue, but got ConfigurationItem instead
```javascript
if (app.configuration) {
  application.configuration = app.configuration.map((item) => Object.assign(new ConfigurationItem(), item));
}
```

[OREE-2061]: https://outreach-io.atlassian.net/browse/OREE-2061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ