### PR TITLE
[OREE-2123] Added test for presence of OutreachContext.email

### DIFF
--- a/src/context/interfaces/IOutreachContext.ts
+++ b/src/context/interfaces/IOutreachContext.ts
@@ -7,6 +7,7 @@ import { IOpportunityContext } from './IOpportunityContext';
 import { IProspectContext } from './IProspectContext';
 import { IHostContext } from './IHostContext';
 import { IConfigurationValue } from './IConfigurationValue';
+import { IEmailContext } from './IEmailContext';
 
 export interface IOutreachContext {
   /**
@@ -64,6 +65,13 @@ export interface IOutreachContext {
    * @type {IProspectContext}
    */
   prospect?: IProspectContext;
+
+  /**
+   * Current Outreach text editor email context information (if any)
+   *
+   * @type {IEmailContext}
+   */
+  email?: IEmailContext;
 
   /**
    * Context of the addon hosting environment

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -64,8 +64,8 @@ describe('sdk tests', () => {
       jest.restoreAllMocks();
     });
 
-    describe('Outreachcontext initialized', () => {
-      it('will resolve context promise when success', async () => {
+    describe('OutreachContext initialized', () => {
+      it('Supported email context parameters are populated', async () => {
         var message = new InitMessage();
         message.result = '200';
         message.application = new Application();
@@ -74,7 +74,15 @@ describe('sdk tests', () => {
           { key: UserContextKeys.ID, value: '1' },
           {
             key: EmailContextKeys.TO,
-            value: '[{"email":"test@user.com","name":"Test User"}]',
+            value: '[{"email":"to@user.com","name":"Test User"}]',
+          },
+          {
+            key: EmailContextKeys.CC,
+            value: '[{"email":"cc@user.com","name":"Test User"}]',
+          },
+          {
+            key: EmailContextKeys.BCC,
+            value: '[{"email":"bcc@user.com","name":"Test User"}]',
           },
           { key: EmailContextKeys.SUBJECT, value: 'Test Subject' },
         ];
@@ -84,7 +92,9 @@ describe('sdk tests', () => {
         const outreachContext = await sdk.init();
 
         expect(outreachContext?.user?.id).toBe('1');
-        expect(outreachContext?.email?.to).toEqual([{ email: 'test@user.com', name: 'Test User' }]);
+        expect(outreachContext?.email?.to).toEqual([{ email: 'to@user.com', name: 'Test User' }]);
+        expect(outreachContext?.email?.cc).toEqual([{ email: 'cc@user.com', name: 'Test User' }]);
+        expect(outreachContext?.email?.bcc).toEqual([{ email: 'bcc@user.com', name: 'Test User' }]);
         expect(outreachContext?.email?.subject).toEqual('Test Subject');
       });
     });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,4 +1,13 @@
-import { ExtensibilitySdk, Message, OAuthDialogCompletedMessage } from '../src/index';
+import {
+  Application,
+  EmailContextKeys,
+  ExtensibilitySdk,
+  InitMessage,
+  ManifestStore,
+  Message,
+  OAuthDialogCompletedMessage,
+  UserContextKeys,
+} from '../src/index';
 import runtime, { RuntimeContext } from '../src/sdk/RuntimeContext';
 import oauthService from '../src/sdk/services/oauthService';
 
@@ -10,11 +19,14 @@ describe('sdk tests', () => {
     let originalEventListener: (event: string, handler: EventListenerOrEventListenerObject) => void;
     let originalOpenPopup: (redirectUri?: string, state?: { [key: string]: string }) => void;
     let originalTimeout: any;
+    let originalClearTimeout: any;
     let originalRuntime: RuntimeContext;
 
     beforeEach(async () => {
       originalTimeout = window.setTimeout;
+      originalClearTimeout = window.clearTimeout;
       window.setTimeout = jest.fn().mockImplementation(() => 123) as any;
+      window.clearTimeout = jest.fn().mockImplementation() as any;
 
       originalOpenPopup = oauthService.openPopup;
       oauthService.openPopup = jest.fn();
@@ -45,10 +57,36 @@ describe('sdk tests', () => {
       runtime.application = originalRuntime.application;
       runtime.origin = originalRuntime.origin;
 
+      window.clearTimeout = originalClearTimeout;
       window.setTimeout = originalTimeout;
       window.addEventListener = originalEventListener;
       oauthService.openPopup = originalOpenPopup;
       jest.restoreAllMocks();
+    });
+
+    describe('Outreachcontext initialized', () => {
+      it('will resolve context promise when success', async () => {
+        var message = new InitMessage();
+        message.result = '200';
+        message.application = new Application();
+        message.application.store = new ManifestStore();
+        message.context = [
+          { key: UserContextKeys.ID, value: '1' },
+          {
+            key: EmailContextKeys.TO,
+            value: '[{"email":"test@user.com","name":"Test User"}]',
+          },
+          { key: EmailContextKeys.SUBJECT, value: 'Test Subject' },
+        ];
+
+        handleMessage(message);
+
+        const outreachContext = await sdk.init();
+
+        expect(outreachContext?.user?.id).toBe('1');
+        expect(outreachContext?.email?.to).toEqual([{ email: 'test@user.com', name: 'Test User' }]);
+        expect(outreachContext?.email?.subject).toEqual('Test Subject');
+      });
     });
 
     describe('OAUTH_DIALOG_COMPLETED', () => {


### PR DESCRIPTION
# [OREE-2123]

Added test for presence of OutreachContext.email
A follow up of #104 

[OREE-2123]: https://outreach-io.atlassian.net/browse/OREE-2123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ