### PR TITLE
[DT-4171] Update CI credentials for npm publish to work

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,6 +62,7 @@ workflows:
       - build_public_package:
           context:
             - npm-credentials
+            - github-credentials
           requires:
             - test
           filters:


### PR DESCRIPTION
# [DT-4171] Update CI credentials for npm publish to work

[DT-4171]: https://outreach-io.atlassian.net/browse/DT-4171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ