### PR TITLE
feat: manifest-url is optional

### DIFF
--- a/docs/schema/2.0/manifest.schema.json
+++ b/docs/schema/2.0/manifest.schema.json
@@ -236,7 +236,7 @@
           "$ref": "./opdpManifest.schema.json"
         }
       },
-      "required": ["manifest", "manifest-url"]
+      "required": ["manifest"]
     },
     "externalInstallationUrl": {
       "type": "string",


### PR DESCRIPTION
## What this PR does / why we need it
Made manifest-url optional. It's for a nicer UX, but it isn't necessary.

## Jira ID

[ADS-1478]

<!-- Notes that may be helpful for anyone reviewing this PR -->

## Notes for your reviewers


[ADS-1478]: https://outreach-io.atlassian.net/browse/ADS-1478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ