### PR TITLE
feat: updated auth for OPDP

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 # See https://help.github.com/articles/about-codeowners/
 * @getoutreach/fnd-ade
+/docs/schema @getoutreach/fnd-ads

--- a/docs/schema/2.0/opdpManifest.schema.json
+++ b/docs/schema/2.0/opdpManifest.schema.json
@@ -14,22 +14,55 @@
       "pattern": "^https://[a-zA-Z0-9-]+\\.[a-zA-Z0-9-/.]+/opdp/v0\\.9$",
       "description": "Base URL of the provider."
     },
-    "authentication": {
-      "type": "object",
-      "properties": {
-        "apiKey": {
+    "securityScheme": {
+      "oneOf": [
+        {
           "type": "object",
           "properties": {
-            "header": {
-              "type": "string",
-              "pattern": "^[_0-9A-Za-z-]+$",
-              "description": "Header name for API key authentication."
+            "apiKey": {
+              "type": "object",
+              "properties": {
+                "header": {
+                  "type": "string",
+                  "pattern": "^[_0-9A-Za-z-]+$",
+                  "description": "Header name for API key authentication."
+                }
+              },
+              "required": ["header"]
             }
           },
-          "required": ["header"]
+          "required": ["apiKey"]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "apiKey"
+            },
+            "name": {
+              "type": "string"
+            },
+            "in": {
+              "type": "string",
+              "const": "header"
+            }
+          },
+          "required": ["type", "name", "in"],
+          "additionalProperties": false
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "const": "oauth2"
+            }
+          },
+          "required": ["type"],
+          "additionalProperties": false
         }
-      },
-      "required": ["apiKey"]
+      ]
     },
     "endpoints": {
       "type": "object",

--- a/docs/schema/2.0/opdpManifest.schema.json
+++ b/docs/schema/2.0/opdpManifest.schema.json
@@ -297,5 +297,5 @@
       }
     }
   },
-  "required": ["name", "baseURL", "authentication", "endpoints"]
+  "required": ["name", "baseURL", "securityScheme", "endpoints"]
 }

--- a/docs/schema/2.0/opdpManifest.schema.json
+++ b/docs/schema/2.0/opdpManifest.schema.json
@@ -19,23 +19,6 @@
         {
           "type": "object",
           "properties": {
-            "apiKey": {
-              "type": "object",
-              "properties": {
-                "header": {
-                  "type": "string",
-                  "pattern": "^[_0-9A-Za-z-]+$",
-                  "description": "Header name for API key authentication."
-                }
-              },
-              "required": ["header"]
-            }
-          },
-          "required": ["apiKey"]
-        },
-        {
-          "type": "object",
-          "properties": {
             "type": {
               "type": "string",
               "const": "apiKey"


### PR DESCRIPTION
<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
An iteration of the auth in OPDP that allows token in header.

We will support 2 modes - api token in a header and oauth. We decided not to provide any more fields in the manifest for oauth for now. It won't be specified in the manifest. We can always formalize it later on.

## Jira ID

[ADS-1542]

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers


[ADS-1542]: https://outreach-io.atlassian.net/browse/ADS-1542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ