### PR TITLE
feat: remove unused category

### DIFF
--- a/docs/schema/2.0/manifest.schema.json
+++ b/docs/schema/2.0/manifest.schema.json
@@ -50,7 +50,6 @@
               "account_based_marketing",
               "account_plan",
               "chat",
-              "conversation_intelligence",
               "crm",
               "direct_mail",
               "inbox",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@getoutreach/extensibility-sdk",
   "license": "MIT",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "private": false,
   "contributors": [
     "Outreach Client Extensibility Team <cxt-sdk@outreach.io>"

--- a/src/manifest/store/Category.ts
+++ b/src/manifest/store/Category.ts
@@ -22,11 +22,6 @@ export enum Category {
   CHAT = 'chat',
 
   /**
-   * Conversation intelligence extension category
-   */
-  CONVERSATION_INTELLIGENCE = 'conversation_intelligence',
-
-  /**
    * CRM extension category
    */
   CRM = 'crm',
@@ -110,7 +105,7 @@ export enum Category {
    * Grouping and navigation category
    */
   GROUPING_AND_NAVIGATION = 'grouping_and_navigation',
-  
+
   /**
    * Agents category
    */


### PR DESCRIPTION
## Description

There are no mentioned of this category in the `client` repo, and also there are no tiles under this category in orexservice:
https://github.com/search?q=repo%3Agetoutreach%2Forexservice+conversation_intelligence&type=code
