### PR TITLE
feat: remove zoomInfoIntent datum

### DIFF
--- a/docs/schema/2.0/opdpManifest.schema.json
+++ b/docs/schema/2.0/opdpManifest.schema.json
@@ -163,7 +163,6 @@
                         "blogPosts",
                         "newsArticles",
                         "tenKSummary",
-                        "zoomInfoIntent",
                         "intent",
                         "websiteVisitSignal",
                         "prospectWebsiteVisitSignal",


### PR DESCRIPTION
<!--
  !!!! README !!!! Please fill this out.

  Please follow conventional commit naming conventions:

  https://www.conventionalcommits.org/en/v1.0.0/#summary
-->

<!-- A short description of what your PR does and what it solves. -->
## What this PR does / why we need it
We're removing support for the `zoominfoIntent` datum from the OPDP spec. This PR updates the opdp manifest schema to remove the datum from the datum list.
## Jira ID

[DP-7226]

<!-- Notes that may be helpful for anyone reviewing this PR -->
## Notes for your reviewers


[DP-7226]: https://outreach-io.atlassian.net/browse/DP-7226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ