### PR TITLE
feat: add KPI tile group [RA-6764]

### DIFF
--- a/docs/schema/2.0/manifest.schema.json
+++ b/docs/schema/2.0/manifest.schema.json
@@ -621,7 +621,8 @@
                   "EXECUTION",
                   "PERFORMANCE",
                   "FIELDS",
-                  "HEALTH_AND_ACTIVITY"
+                  "HEALTH_AND_ACTIVITY",
+                  "KPI"
                 ]
               },
               "context": {

--- a/src/manifest/extensions/tiles/TileGroup.ts
+++ b/src/manifest/extensions/tiles/TileGroup.ts
@@ -129,4 +129,9 @@ export enum TileGroup {
    * Health and activity group
    */
   HEALTH_AND_ACTIVITY = 'HEALTH_AND_ACTIVITY',
+
+  /**
+   * KPI group
+   */
+  KPI = 'KPI',
 }


### PR DESCRIPTION
## Description

Adds `KPI` to the `TileGroup` enum (and corresponding manifest JSON schema) so internal apps can declare `group: KPI` on tile extensions.

Required for [RA-6764](https://outreach-io.atlassian.net/browse/RA-6764) — surfacing the 12 new `custom-dashboard-kpi-*` tiles under a dedicated **KPI** section in the client's Add Tiles modal.

## Context

- The giraffe `TileGroup.KPI` enum is already deployed to the Hive CDN superschema and the client (`@outreach/giraffe-types`) already consumes it.
- orexservice PR [#1046](https://github.com/getoutreach/orexservice/pull/1046) needs to set `group: kpi` on the 12 KPI tile yamls, but the embedded manifest schema (synced from this SDK via `make gogenerate`) rejects the value until KPI is added here.

## Changes

- `src/manifest/extensions/tiles/TileGroup.ts` — add `KPI = 'KPI'` enum member.
- `docs/schema/2.0/manifest.schema.json` — add `"KPI"` to the `extensions[].group` enum list.

## Validation

- `yarn build` ✅
- `yarn test` ✅ (262 passed)

## Follow-up

After merge + release, run `make gogenerate` in orexservice to pick up the new schema, then PR #1046 CI will go green.


[RA-6764]: https://outreach-io.atlassian.net/browse/RA-6764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ