### PR TITLE
chore: bump version to 1.4.3 [RA-6764]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@getoutreach/extensibility-sdk",
   "license": "MIT",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "private": false,
   "contributors": [
     "Outreach Client Extensibility Team <cxt-sdk@outreach.io>"


### PR DESCRIPTION
## What
Bumps `package.json` version from `1.4.2` to `1.4.3`.

## Why
The KPI tile group addition (#177) merged without bumping `package.json`. The CI's `check-version` step in [.circleci/config.yml](.circleci/config.yml) halts the `build_public_package` job unless the version changed in the last commit on `main`, so #177 never published to npm — `npm view @getoutreach/extensibility-sdk version` still returns `1.4.2` and the new `TileGroup.KPI` enum value isn't yet available to consumers.

Patch bump matches repo convention (every prior `feat:` PR also bumped patch, e.g. `1.4.0 → 1.4.1` for #168 / tile groups, `1.4.1 → 1.4.2` for #171 / TileGroup export).

## How
`sed` replaced the single version line in `package.json`. No other changes.

## Verification
After merge, watch CircleCI on `main` — the `build_public_package` job should pass `check-version` and run `npm publish`. Then `npm view @getoutreach/extensibility-sdk version` will report `1.4.3`.